### PR TITLE
Add comprehensive unit tests and raise coverage toward 100%

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,25 @@
 
   The C++ engine, benchmarks, and validation harness live in `cklut/`.
 
+## Bug fixes
+
+* `guess_gamlss()` referenced an undefined `dt` (which resolved to `stats::dt`)
+  instead of its local `data.table`, so the function always errored before
+  returning. It now completes and returns the predicted variable as documented.
+
+## Testing and coverage
+
+* Greatly expanded the `tinytest` suite to systematically cover the package's
+  functions and C++ helpers: the `frXXX` random generators, parquet I/O
+  round-trips, the gamlss/polr/reldist helpers, `cklut` (build/lookup/export
+  plus the multi-shard and `warm` prefetch paths), and the compiled helpers
+  (`shift_bypid*`, `counts`/`tableRcpp`, the distribution validation/`log_p`
+  branches, parameter recycling, and clamping). Code that cannot be exercised
+  by unit tests — package load/unload hooks, real package-install machinery,
+  Windows-only and network-only paths, `requireNamespace` guards for Suggests
+  packages, and defensive guards — is marked with `# nocov`. Overall test
+  coverage rises to roughly 95%.
+
 ## Notes
 
 * CSV export preserves factor *labels* but not factor level order; rebuilding

--- a/R/CKutils.R
+++ b/R/CKutils.R
@@ -50,6 +50,7 @@
 .datatable.aware = TRUE
 
 # Initialize data.table API when package loads
+# nocov start: package load hook, executed by R at load time, not callable in tests
 .onLoad <- function(libname, pkgname) {
   # Initialize the data.table API for C++ functions
   if (!requireNamespace("data.table", quietly = TRUE)) {
@@ -69,10 +70,11 @@
     }
   }, error = function(e) {
     # Don't fail package loading if data.table initialization fails
-    warning("data.table initialization failed: ", e$message, 
+    warning("data.table initialization failed: ", e$message,
             ". Some functions may not work properly.")
   })
 }
+# nocov end
 
 # Prevent R CMD check from complaining about the use of pipe expressions
 # standard data.table variables

--- a/R/lookup_dt.R
+++ b/R/lookup_dt.R
@@ -180,9 +180,9 @@ lookup_dt <- function(
   # Calculate cardinality and minimum lookup values for each key column
   for (j in on) {
     # Additional safety checks for column data
-    if (is.null(tbl[[j]]) || is.null(lookup_tbl[[j]])) {
+    if (is.null(tbl[[j]]) || is.null(lookup_tbl[[j]])) {       # nocov start
       stop("Column '", j, "' contains NULL data")
-    }
+    }                                                          # nocov end
     
     if (is.factor(lookup_tbl[[j]])) {
       lv <- levels(lookup_tbl[[j]])
@@ -271,9 +271,9 @@ lookup_dt <- function(
     } else {
       return(invisible(dtsubset(lookup_tbl, rownum, return_cols)))
     }
-  }, error = function(e) {
+  }, error = function(e) {                                     # nocov start
     stop("Error in data.table subset operation: ", e$message)
-  })
+  })                                                           # nocov end
 }
 
 

--- a/R/misc_functions.R
+++ b/R/misc_functions.R
@@ -16,9 +16,11 @@
 ## or write to the Free Software Foundation, Inc., 51 Franklin Street,
 ## Fifth Floor, Boston, MA 02110-1301  USA.
 
+# nocov start: package unload hook, executed by R at unload time, not callable in tests
 .onUnload <- function(libpath) {
   library.dynam.unload("CKutils", libpath)
 }
+# nocov end
 
 #' Get Dropbox path
 #'
@@ -47,7 +49,7 @@ get_dropbox_path <-
     }
     type <- match.arg(type)
     if (type[[1]] == "personal") {
-      if (.Platform$OS.type == "windows") {
+      if (.Platform$OS.type == "windows") {   # nocov start: Windows-only, coverage runs on Linux
         if (file.exists(paste0(Sys.getenv("APPDATA"), "/Dropbox/info.json"))) {
           # for older versions of Dropbox
           dropbox_path <-
@@ -65,7 +67,7 @@ get_dropbox_path <-
               "/Dropbox/info.json"
             ))$personal$path
         }
-      } else {
+      } else {                                # nocov end
         if (file.exists("~/.dropbox/info.json")) {
           dropbox_path <-
             jsonlite::read_json("~/.dropbox/info.json")$personal$path
@@ -73,7 +75,7 @@ get_dropbox_path <-
       }
     }
     if (type[[1]] == "business") {
-      if (.Platform$OS.type == "windows") {
+      if (.Platform$OS.type == "windows") {   # nocov start: Windows-only, coverage runs on Linux
         if (file.exists(paste0(Sys.getenv("APPDATA"), "/Dropbox/info.json"))) {
           # for older versions of Dropbox
           dropbox_path <-
@@ -91,7 +93,7 @@ get_dropbox_path <-
               "/Dropbox/info.json"
             ))$business$path
         }
-      } else {
+      } else {                                # nocov end
         if (file.exists("~/.dropbox/info.json")) {
           dropbox_path <-
             jsonlite::read_json("~/.dropbox/info.json")$business$path
@@ -127,7 +129,7 @@ get_dropbox_path <-
 #' }
 get_pcloud_path <- function(pathtail = character(0)) {
   if (.Platform$OS.type == "windows") {
-    pcloud_path <- "p:\\"
+    pcloud_path <- "p:\\"                # nocov: Windows-only, coverage runs on Linux
   } else {
     pcloud_path <- "~/pCloudDrive/"
   }
@@ -806,7 +808,7 @@ read_parquet_dt <- function(
 #' @export
 validate_gamlss <- function(dtb, gamlss_obj, mc = 10L, orig_data = dtb) {
   if (!requireNamespace("gamlss", quietly = TRUE)) {
-    stop("Please install package gamlss first.")
+    stop("Please install package gamlss first.")             # nocov
   }
   stopifnot(
     "gamlss" %in% class(gamlss_obj),
@@ -856,7 +858,7 @@ guess_gamlss <- function(
   nc = 1L
 ) {
   if (!requireNamespace("gamlss", quietly = TRUE)) {
-    stop("Please install package gamlss first.")
+    stop("Please install package gamlss first.")             # nocov
   }
   stopifnot(
     "gamlss" %in% class(gamlss_obj),
@@ -873,10 +875,10 @@ guess_gamlss <- function(
   dtu <- unique(dtb[, ..nam_var]) # otherwise too slow
   dtu <- split(dtu, dtu$year)
   if ("RevoUtilsMath" %in% (.packages())) {
-    tt <- get("getMKLthreads", mode = "function")()
+    tt <- get("getMKLthreads", mode = "function")()        # nocov
   }
   if ("RevoUtilsMath" %in% (.packages())) {
-    get("setMKLthreads", mode = "function")(1L)
+    get("setMKLthreads", mode = "function")(1L)            # nocov
   }
   dtu <- parallel::mclapply(
     dtu,
@@ -894,7 +896,7 @@ guess_gamlss <- function(
     mc.cores = nc
   )
   if ("RevoUtilsMath" %in% (.packages())) {
-    get("setMKLthreads", mode = "function")(tt)
+    get("setMKLthreads", mode = "function")(tt)            # nocov
   }
   dtu <- rbindlist(dtu)
   # dtu[, (nam_param) := gamlss::predictAll(gamlss_obj,
@@ -903,7 +905,7 @@ guess_gamlss <- function(
   #                                        data = orig_data)]
   dtb[dtu, on = nam_var, (nam_param) := mget(paste0("i.", nam_param))]
   dtb[, p := get(paste0("rank_", nam_y))]
-  stopifnot(dt[, all(between(p, 0, 1, incbounds = FALSE))])
+  stopifnot(dtb[, all(between(p, 0, 1, incbounds = FALSE))])
   dtb[, (nam_y) := do.call(nam_dist, .SD), .SDcols = c("p", nam_param)]
   dtb[, c("p", nam_param) := NULL]
 }
@@ -940,10 +942,10 @@ guess_gamlss <- function(
 #' }
 guess_polr <- function(dtb, polr_obj) {
   if (!requireNamespace("MASS", quietly = TRUE)) {
-    stop("Please install package MASS first.")
+    stop("Please install package MASS first.")               # nocov
   }
   if (!requireNamespace("matrixStats", quietly = TRUE)) {
-    stop("Please install package matrixStats first.")
+    stop("Please install package matrixStats first.")        # nocov
   }
   stopifnot("polr" %in% class(polr_obj), is.data.table(dtb))
   nam_y <- as.character(polr_obj$call$formula[[2]])
@@ -1094,12 +1096,12 @@ reldist_diagnostics <- function(
 ) {
   opar <- par(no.readonly = TRUE)
   on.exit(par(opar))
-  if (!requireNamespace("reldist", quietly = TRUE)) {
+  if (!requireNamespace("reldist", quietly = TRUE)) {        # nocov start
     stop(
       "Package \"reldist\" needed for this function to work. Please install it.",
       call. = FALSE
     )
-  }
+  }                                                          # nocov end
 
   reference_dens <- density(reference, weights = reference_wt)
   comparison_dens <- density(comparison, weights = comparison_wt)

--- a/R/package_ops.R
+++ b/R/package_ops.R
@@ -124,10 +124,12 @@ installLocalPackage <- function(pkg_path, debug = TRUE) {
   # Read package name from DESCRIPTION file
   desc_path <- file.path(pkg_path, "DESCRIPTION")
   pkg_name <- if (file.exists(desc_path)) {
-    read.dcf(desc_path, fields = "Package")[1]
+    read.dcf(desc_path, fields = "Package")[1]      # nocov
   } else {
     stop("DESCRIPTION file not found in: ", pkg_path)
   }
+  # nocov start: performs a real package build/install (roxygenise + R CMD INSTALL),
+  # which has side effects and cannot run inside the unit-test suite.
   detach_package(pkg_name)
 
   rscript(
@@ -185,6 +187,7 @@ installLocalPackage <- function(pkg_path, debug = TRUE) {
       message(paste0("Failed to install ", pkg_name, " package: "), e$message)
     }
   )
+  # nocov end
 }
 
 #' @title Install Local Package If Changed
@@ -225,18 +228,20 @@ installLocalPackage <- function(pkg_path, debug = TRUE) {
 #' @export
 installLocalPackageIfChanged <- function(pkg_path, snapshot_path, debug = TRUE) {
   snapshot <- if (file.exists(snapshot_path)) {
-    changedFiles(readRDS(snapshot_path))
+    changedFiles(readRDS(snapshot_path))            # nocov
   } else {
     NULL
   }
 
   desc_path <- file.path(pkg_path, "DESCRIPTION")
   pkg_name <- if (file.exists(desc_path)) {
-    read.dcf(desc_path, fields = "Package")[1]
+    read.dcf(desc_path, fields = "Package")[1]      # nocov
   } else {
     stop("DESCRIPTION file not found in: ", pkg_path)
   }
 
+  # nocov start: branches into installLocalPackage (a real build/install) and
+  # rewrites the on-disk snapshot; both have side effects unsuitable for tests.
   needs_install <- !requireNamespace(pkg_name, quietly = TRUE) ||
     is.null(snapshot) ||
     any(nzchar(unlist(snapshot[c("added", "deleted", "changed")])))
@@ -258,6 +263,7 @@ installLocalPackageIfChanged <- function(pkg_path, snapshot_path, debug = TRUE) 
   }
 
   invisible(NULL)
+  # nocov end
 }
 
 
@@ -450,6 +456,8 @@ dependencies <-
       
       # Install and/or load package
       if (needs_install || !myrequire(pkg)) {
+        # nocov start: actually downloads/installs from a repository; tests must
+        # never trigger a real install.packages(), so this path is excluded.
         # Install package
         tryCatch({
           if (verbose) {
@@ -457,7 +465,7 @@ dependencies <-
           } else {
             suppressMessages(install.packages(pkgs = pkg, quiet = quiet))
           }
-          
+
           # Verify installation and loading
           if (myrequire(pkg)) {
             results[pkg, 'installed'] <- TRUE
@@ -469,6 +477,7 @@ dependencies <-
         }, error = function(e) {
           warning(sprintf("Failed to install package %s: %s", pkg, e$message))
         })
+        # nocov end
       } else {
         # Package loaded successfully without installation
         results[pkg, 'loaded'] <- TRUE

--- a/inst/tinytest/test-cklut_extra.R
+++ b/inst/tinytest/test-cklut_extra.R
@@ -1,0 +1,254 @@
+# Extra coverage tests for R/cklut.R -- targets uncovered branches:
+#   .cklut_value_type (all type branches incl. error)
+#   cklut_build (file-type dispatch, input validation/error paths, value_types
+#               override, double/int/logical/character/integer64 value cols)
+#   print.cklut, cklut_lookup (error/validation paths), cklut_to_dt,
+#   cklut_to_parquet/csv round-trips, cklut_open, is_valid_lookup_tbl,
+#   set_lookup_tbl_key.
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+suppressMessages(library(data.table))
+
+# ---------------------------------------------------------------------------
+# A small dense grid with one of every supported value-column type.
+# keys: a (integer, consecutive) and grp (factor)
+# ---------------------------------------------------------------------------
+make_tbl <- function() {
+  dt <- CJ(a = 1:3, grp = factor(c("x", "y"), levels = c("x", "y")))
+  n <- nrow(dt)
+  dt[, dbl := as.double(a) + 0.5]                 # f64
+  dt[, intc := as.integer(a) * 10L]               # i32
+  dt[, lg  := (a %% 2L) == 0L]                    # lgl
+  dt[, chr := paste0("v", a)]                     # character -> str
+  dt[, fct := factor(c("lo", "hi")[1L + (a %% 2L)],
+                     levels = c("lo", "hi"))]      # factor -> str
+  dt[]
+}
+
+keys  <- c("a", "grp")
+tbl   <- make_tbl()
+base  <- tempfile("ckx")
+ck    <- cklut_build(copy(tbl), base, keys = keys)
+
+# --- build returns a cklut handle; schema is sane --------------------------
+expect_inherits(ck, "cklut", info = "cklut_build returns cklut handle")
+expect_inherits(cklut_open(paste0(base, ".ckmeta")), "cklut",
+                info = "cklut_open returns cklut handle")
+expect_equal(ck$schema$n_rows, as.double(nrow(tbl)), info = "row count")
+
+# --- .cklut_value_type inference across all branches -----------------------
+# (.cklut_value_type is internal; reach it through the inferred value_types)
+vt <- ck$schema$value_types
+names(vt) <- ck$schema$value_names
+expect_equal(unname(vt["dbl"]),  "f64", info = "double -> f64")
+expect_equal(unname(vt["intc"]), "i32", info = "integer -> i32")
+expect_equal(unname(vt["lg"]),   "lgl", info = "logical -> lgl")
+expect_equal(unname(vt["chr"]),  "str", info = "character -> str")
+expect_equal(unname(vt["fct"]),  "str", info = "factor -> str")
+
+# --- integer64 value column -> i64 (the inherits("integer64") branch) ------
+if (requireNamespace("bit64", quietly = TRUE)) {
+  suppressMessages(library(bit64))
+  tbl64 <- copy(tbl)
+  tbl64[, big := as.integer64(a) * 1000L]
+  base64 <- tempfile("ckx64")
+  ck64 <- cklut_build(copy(tbl64), base64, keys = keys)
+  vt64 <- ck64$schema$value_types
+  names(vt64) <- ck64$schema$value_names
+  expect_equal(unname(vt64["big"]), "i64", info = "integer64 -> i64")
+}
+
+# --- .cklut_value_type error branch: unsupported column type ---------------
+# A list/complex value column is unsupported.
+bad <- copy(tbl)
+bad[, cx := complex(real = a, imaginary = 0)]
+expect_error(cklut_build(copy(bad), tempfile("ckbad"), keys = keys),
+             pattern = "unsupported value column type",
+             info = ".cklut_value_type stops on unsupported type")
+
+# --- value_types override branch ------------------------------------------
+# Force the integer column 'intc' to be stored as f64.
+base_ov <- tempfile("ckov")
+ck_ov <- cklut_build(copy(tbl), base_ov, keys = keys,
+                     value_types = c(intc = "f64"))
+vt_ov <- ck_ov$schema$value_types
+names(vt_ov) <- ck_ov$schema$value_names
+expect_equal(unname(vt_ov["intc"]), "f64", info = "value_types override -> f64")
+
+# ---------------------------------------------------------------------------
+# cklut_build input-validation / error paths
+# ---------------------------------------------------------------------------
+# unsupported file extension
+expect_error(cklut_build("nope.txt", tempfile("ckbad2"), keys = keys),
+             pattern = "unsupported file type",
+             info = "build: bad file extension")
+
+# missing keys argument
+expect_error(cklut_build(copy(tbl), tempfile("ckbad3")),
+             pattern = "`keys` is required",
+             info = "build: missing keys")
+# empty keys
+expect_error(cklut_build(copy(tbl), tempfile("ckbad3b"), keys = character(0)),
+             pattern = "`keys` is required",
+             info = "build: empty keys")
+
+# keys not present in data
+expect_error(cklut_build(copy(tbl), tempfile("ckbad4"), keys = c("a", "nope")),
+             pattern = "keys not in data",
+             info = "build: key not in data")
+
+# no value columns (all columns are keys)
+onlykeys <- tbl[, ..keys]
+expect_error(cklut_build(copy(onlykeys), tempfile("ckbad5"), keys = keys),
+             pattern = "no value columns",
+             info = "build: no value columns")
+
+# explicit empty values vector
+expect_error(cklut_build(copy(tbl), tempfile("ckbad5b"), keys = keys,
+                         values = character(0)),
+             pattern = "no value columns",
+             info = "build: empty values vector")
+
+# unsupported key type (logical key)
+badkey <- copy(tbl)
+badkey[, lk := rep(c(TRUE, FALSE), length.out = .N)]
+expect_error(cklut_build(copy(badkey), tempfile("ckbad6"),
+                         keys = c("a", "lk"),
+                         values = c("dbl")),
+             pattern = "must be integer, numeric or factor",
+             info = "build: unsupported key type")
+
+# check=TRUE: not a dense grid (drop a row)
+notdense <- tbl[-1L]
+expect_error(cklut_build(copy(notdense), tempfile("ckbad7"), keys = keys,
+                         check = TRUE),
+             pattern = "not a dense grid",
+             info = "build: non-dense grid")
+
+# check=TRUE: duplicated keys (still right row count but not unique)
+dup <- copy(tbl)
+dup[2L, a := tbl[[1L, "a"]]]
+dup[2L, grp := tbl[[1L, "grp"]]]
+expect_error(cklut_build(copy(dup), tempfile("ckbad8"), keys = keys,
+                         check = TRUE),
+             pattern = "not a dense grid|not unique",
+             info = "build: duplicated keys / dense check")
+
+# check=FALSE bypasses the grid validation (non-dense grid builds fine)
+ck_nc <- cklut_build(copy(tbl), tempfile("cknc"), keys = keys, check = FALSE)
+expect_inherits(ck_nc, "cklut", info = "build: check=FALSE skips grid check")
+
+# character key path + data.frame (not data.table) input coercion ----------
+dfin <- as.data.frame(make_tbl())
+dfin$grp <- as.character(dfin$grp)               # character key -> sort/match path
+ck_chr <- cklut_build(dfin, tempfile("ckchr"), keys = keys)
+expect_inherits(ck_chr, "cklut", info = "build: char key + df coercion")
+
+# ---------------------------------------------------------------------------
+# print.cklut
+# ---------------------------------------------------------------------------
+out <- capture.output(print(ck))
+expect_true(any(grepl("<cklut>", out, fixed = TRUE)),
+            info = "print: header line")
+expect_true(any(grepl("keys", out)),   info = "print: keys line")
+expect_true(any(grepl("values", out)), info = "print: values line")
+# print returns its argument invisibly
+expect_identical(print(ck), ck, info = "print returns x invisibly")
+
+# ---------------------------------------------------------------------------
+# cklut_lookup: success + error/validation paths
+# ---------------------------------------------------------------------------
+q <- data.table(a = c(1L, 2L, 3L, 99L),                  # 99 -> no match -> NA
+                grp = factor(c("x", "y", "x", "y"),
+                             levels = c("x", "y")))
+
+# accept a path (character) as `ck` -> cklut_open branch
+got_path <- suppressMessages(cklut_lookup(copy(q), paste0(base, ".ckmeta"),
+                                          merge = FALSE))
+expect_inherits(got_path, "data.table", info = "lookup: path -> opens handle")
+expect_equal(nrow(got_path), nrow(q), info = "lookup: one row per query")
+expect_true(is.na(got_path$dbl[4L]), info = "lookup: no-match -> NA")
+
+# values match the source table for the in-range rows
+got <- suppressMessages(cklut_lookup(copy(q), ck, merge = FALSE))
+expect_equal(got$dbl[1:3], c(1.5, 2.5, 3.5), info = "lookup: double values")
+expect_equal(got$intc[1:3], c(10L, 20L, 30L), info = "lookup: integer values")
+
+# merge = TRUE adds value columns to tbl by reference
+m <- copy(q)
+suppressMessages(cklut_lookup(m, ck, merge = TRUE))
+expect_true(all(c("dbl", "intc", "lg", "chr", "fct") %in% names(m)),
+            info = "lookup: merge=TRUE adds value cols")
+
+# merge=TRUE on a data.frame triggers as.data.table coercion branch
+mdf <- as.data.frame(q)
+res_df <- suppressMessages(cklut_lookup(mdf, ck, merge = TRUE))
+expect_inherits(res_df, "data.table", info = "lookup: merge coerces df -> dt")
+
+# as.data.table = FALSE -> plain list
+li <- suppressMessages(cklut_lookup(copy(q), ck, merge = FALSE,
+                                    as.data.table = FALSE))
+expect_true(is.list(li) && !is.data.table(li),
+            info = "lookup: as.data.table=FALSE -> list")
+
+# check=FALSE suppresses the no-match message (no error expected)
+got_nc <- cklut_lookup(copy(q), ck, merge = FALSE, check = FALSE)
+expect_equal(nrow(got_nc), nrow(q), info = "lookup: check=FALSE works")
+
+# error: ck not a handle / path
+expect_error(cklut_lookup(copy(q), 42L),
+             pattern = "must be a cklut handle or .ckmeta path",
+             info = "lookup: bad ck arg")
+
+# error: excluding a key column
+expect_error(cklut_lookup(copy(q), ck, exclude_col = "a"),
+             pattern = "cannot exclude key column",
+             info = "lookup: exclude key column")
+
+# error: tbl missing a key column
+expect_error(cklut_lookup(q[, .(a)], ck),
+             pattern = "missing key column",
+             info = "lookup: missing key in tbl")
+
+# ---------------------------------------------------------------------------
+# cklut_to_dt / cklut_to_csv / cklut_to_parquet round-trips
+# ---------------------------------------------------------------------------
+full <- cklut_to_dt(ck)
+expect_inherits(full, "data.table", info = "to_dt: data.table")
+expect_equal(nrow(full), nrow(tbl), info = "to_dt: full grid row count")
+expect_true(all(c(keys, "dbl", "intc", "lg", "chr", "fct") %in% names(full)),
+            info = "to_dt: has keys + values")
+
+# to_dt accepts a path too
+full_p <- cklut_to_dt(paste0(base, ".ckmeta"))
+expect_equal(nrow(full_p), nrow(tbl), info = "to_dt: path arg")
+
+# CSV round-trip
+csv <- tempfile(fileext = ".csv")
+expect_equal(cklut_to_csv(ck, csv), csv, info = "to_csv returns path")
+expect_true(file.exists(csv), info = "to_csv wrote file")
+ck_csv <- cklut_build(csv, tempfile("ckcsv"), keys = keys)
+got_csv <- suppressMessages(cklut_lookup(copy(q), ck_csv, merge = FALSE))
+expect_equal(got_csv$dbl, got$dbl, info = "csv round-trip: double values")
+
+# Parquet round-trip (write to tempfile, rebuild, verify)
+if (requireNamespace("arrow", quietly = TRUE)) {
+  pq <- tempfile(fileext = ".parquet")
+  expect_equal(cklut_to_parquet(ck, pq), pq, info = "to_parquet returns path")
+  expect_true(file.exists(pq), info = "to_parquet wrote file")
+  ck_pq <- cklut_build(pq, tempfile("ckpq"), keys = keys)
+  got_pq <- suppressMessages(cklut_lookup(copy(q), ck_pq, merge = FALSE))
+  expect_equal(got_pq$dbl, got$dbl, info = "parquet round-trip: double values")
+  expect_equal(got_pq$intc, got$intc, info = "parquet round-trip: int values")
+}
+
+# ---------------------------------------------------------------------------
+# is_valid_lookup_tbl / set_lookup_tbl_key round-trip
+# ---------------------------------------------------------------------------
+lt <- copy(tbl)
+set_lookup_tbl_key(lt, keys)
+expect_equal(key(lt), keys, info = "set_lookup_tbl_key sets the key")
+expect_true(is_valid_lookup_tbl(lt, keys),
+            info = "is_valid_lookup_tbl: dense unique grid is valid")

--- a/inst/tinytest/test-cklut_shards.R
+++ b/inst/tinytest/test-cklut_shards.R
@@ -1,0 +1,47 @@
+# Tests for the multi-shard / warm-up code paths of cklut.
+# A small `max_bytes` forces the table to be split across several shards, which
+# exercises the fast index->shard division (detail::FastDivU64::div) and the
+# per-shard prefetch/populate warm-up path (cklut_open(warm = TRUE)).
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+suppressMessages(library(data.table))
+
+set.seed(11)
+
+# A dense grid with enough rows that a tiny shard cap creates many shards.
+# id spans 1:64 (a power of two) to also exercise power-of-two strides.
+grid <- CJ(id = 1:64, grp = 1:50)
+grid[, val := id + grp / 100]          # double value column
+grid[, cnt := as.integer(id * grp)]    # integer value column
+
+keys <- c("id", "grp")
+
+base <- tempfile("ckshard")
+# 2 KB shard cap -> the payload is split into many shards.
+ck <- cklut_build(copy(grid), base, keys = keys, max_bytes = 2048)
+expect_inherits(ck, "cklut", info = "multi-shard build returns a handle")
+expect_true(ck$schema$n_shards > 1,
+            info = "small max_bytes produces more than one shard")
+
+# Query the whole grid back; lookups must cross shard boundaries correctly,
+# which forces div() to map each linear index to its shard.
+q <- grid[, ..keys][sample(.N)]        # shuffled so lookups hit many shards
+got <- suppressMessages(cklut_lookup(copy(q), ck, merge = FALSE))
+
+oracle <- suppressMessages(lookup_dt(copy(q), copy(grid), merge = FALSE,
+                                     check_lookup_tbl_validity = FALSE))
+expect_equal(got$val, oracle$val, info = "multi-shard lookup: double column correct")
+expect_equal(got$cnt, oracle$cnt, info = "multi-shard lookup: integer column correct")
+
+# Reopen the same on-disk table with warm = TRUE: this walks every shard and
+# calls willneed() + populate() to pull all pages resident before returning.
+ck_warm <- cklut_open(paste0(base, ".ckmeta"), warm = TRUE)
+expect_inherits(ck_warm, "cklut", info = "warm open returns a handle")
+got_warm <- suppressMessages(cklut_lookup(copy(q), ck_warm, merge = FALSE))
+expect_equal(got_warm$val, oracle$val, info = "warm multi-shard lookup correct")
+
+# A full round-trip of a multi-shard table back to a data.table.
+rt <- cklut_to_dt(ck)
+expect_equal(nrow(rt), nrow(grid), info = "multi-shard cklut_to_dt full grid")

--- a/inst/tinytest/test-counts_cpp.R
+++ b/inst/tinytest/test-counts_cpp.R
@@ -1,0 +1,56 @@
+# Tests for the C++ tabulation helpers in src/counts.cpp:
+#   counts()   (exported) - frequency table preserving value-type dispatch
+#   tableRcpp() (exported via Rcpp) - thin wrapper over Rcpp::table
+# Existing tests cover the numeric/character/logical paths of counts(); here we
+# add the integer path, the character-NA path, and the full tableRcpp dispatch.
+
+tableRcpp <- getFromNamespace("tableRcpp", "CKutils")
+
+# -----------------------------------------------------------------------------
+# counts(): integer (INTSXP) dispatch branch
+# -----------------------------------------------------------------------------
+int_res <- counts(c(1L, 2L, 2L, 3L, 3L, 3L))
+expect_true(is.integer(int_res), info = "counts(integer) returns integer")
+expect_equal(as.vector(int_res), c(1L, 2L, 3L),
+             info = "counts(integer) tallies correctly")
+expect_equal(names(int_res), c("1", "2", "3"),
+             info = "counts(integer) names are the values")
+
+# integer NA handling
+int_na <- counts(c(1L, NA_integer_, 1L, 2L, NA_integer_))
+expect_true(any(is.na(names(int_na))) || "NA" %in% names(int_na),
+            info = "counts(integer) keeps NA bucket")
+
+# -----------------------------------------------------------------------------
+# counts(): character path with NA (exercises the NA-name fix-up)
+# -----------------------------------------------------------------------------
+chr_na <- counts(c("a", "b", NA, "a", NA, "b"))
+expect_equal(sum(chr_na), 6L, info = "counts(character w/ NA) totals all elements")
+expect_true(any(is.na(names(chr_na))),
+            info = "counts(character) restores NA as a real NA name")
+
+# -----------------------------------------------------------------------------
+# counts(): unsupported type errors
+# -----------------------------------------------------------------------------
+expect_error(counts(complex(real = 1, imaginary = 1)),
+             pattern = "unrecognized SEXP type",
+             info = "counts() errors on unsupported (complex) type")
+
+# -----------------------------------------------------------------------------
+# tableRcpp(): all four supported dispatch branches + error branch
+# -----------------------------------------------------------------------------
+t_int <- tableRcpp(c(1L, 1L, 2L, 3L, 3L, 3L))
+expect_equal(as.vector(t_int), c(2L, 1L, 3L), info = "tableRcpp(integer)")
+
+t_dbl <- tableRcpp(c(1.5, 1.5, 2.5))
+expect_equal(as.vector(t_dbl), c(2L, 1L), info = "tableRcpp(double)")
+
+t_chr <- tableRcpp(c("x", "y", "x", "x"))
+expect_equal(as.vector(t_chr[order(names(t_chr))]), c(3L, 1L), info = "tableRcpp(character)")
+
+t_lgl <- tableRcpp(c(TRUE, FALSE, TRUE))
+expect_equal(sum(t_lgl), 3L, info = "tableRcpp(logical)")
+
+expect_error(tableRcpp(complex(real = 1, imaginary = 1)),
+             pattern = "unrecognized SEXP type",
+             info = "tableRcpp() errors on unsupported type")

--- a/inst/tinytest/test-cpp_lookup_validation.R
+++ b/inst/tinytest/test-cpp_lookup_validation.R
@@ -1,0 +1,108 @@
+# Tests for the validation / error branches of the C++ helpers in
+# src/lookup_dt.cpp: fct_to_int_cpp (exported), and the internal
+# starts_from_1_cpp and dtsubset (reached via the package namespace).
+
+starts_from_1_cpp <- getFromNamespace("starts_from_1_cpp", "CKutils")
+dtsubset          <- getFromNamespace("dtsubset", "CKutils")
+
+# -----------------------------------------------------------------------------
+# fct_to_int_cpp
+# -----------------------------------------------------------------------------
+expect_error(fct_to_int_cpp(NULL), pattern = "NULL",
+             info = "fct_to_int_cpp errors on NULL input")
+expect_error(fct_to_int_cpp(1L), pattern = "not a factor",
+             info = "fct_to_int_cpp errors on non-factor input")
+expect_error(fct_to_int_cpp("a"), pattern = "not a factor",
+             info = "fct_to_int_cpp errors on character input")
+
+f <- factor(c("b", "a", "c", "a"), levels = c("a", "b", "c"))
+expect_equal(fct_to_int_cpp(f), c(2L, 1L, 3L, 1L),
+             info = "fct_to_int_cpp returns underlying integer codes (copy)")
+expect_null(attr(fct_to_int_cpp(f), "levels"),
+            info = "fct_to_int_cpp strips levels attribute")
+expect_true(is.integer(fct_to_int_cpp(f, inplace = TRUE)),
+            info = "fct_to_int_cpp inplace=TRUE returns an integer vector")
+
+# -----------------------------------------------------------------------------
+# starts_from_1_cpp
+# -----------------------------------------------------------------------------
+tbl <- data.frame(
+  a = c(3L, 5L, NA_integer_, 7L),
+  f = factor(c("x", "y", "z", "x"), levels = c("x", "y", "z")),
+  ch = c("p", "q", "r", "s"),
+  stringsAsFactors = FALSE
+)
+
+# index out of bounds for 'on'
+expect_error(starts_from_1_cpp(tbl, c("a"), 0L, list(1L), list(10L)),
+             pattern = "out of bounds", info = "starts_from_1_cpp: i < 1")
+expect_error(starts_from_1_cpp(tbl, c("a"), 2L, list(1L), list(10L)),
+             pattern = "out of bounds", info = "starts_from_1_cpp: i > on size")
+# index out of bounds for min_lookup / cardinality
+expect_error(starts_from_1_cpp(tbl, c("a", "f"), 2L, list(1L), list(10L)),
+             pattern = "out of bounds for min_lookup",
+             info = "starts_from_1_cpp: i beyond min_lookup/cardinality length")
+# column not present in tbl
+expect_error(starts_from_1_cpp(tbl, c("missing"), 1L, list(1L), list(10L)),
+             pattern = "not found", info = "starts_from_1_cpp: column not found")
+# NULL min_lookup / cardinality entries
+expect_error(starts_from_1_cpp(tbl, c("a"), 1L, list(NULL), list(10L)),
+             pattern = "NULL", info = "starts_from_1_cpp: NULL min_lookup entry")
+expect_error(starts_from_1_cpp(tbl, c("a"), 1L, list(1L), list(NULL)),
+             pattern = "NULL", info = "starts_from_1_cpp: NULL cardinality entry")
+# non-positive cardinality
+expect_error(starts_from_1_cpp(tbl, c("a"), 1L, list(1L), list(0L)),
+             pattern = "positive", info = "starts_from_1_cpp: cardinality <= 0")
+
+# integer column happy path + NA + out-of-range -> NA
+out_int <- starts_from_1_cpp(tbl, c("a"), 1L, list(2L), list(4L))
+# offset = min_lookup - 1 = 1; values: 3->2, 5->4, NA->NA, 7->6 (>card=4 -> NA)
+expect_equal(out_int, c(2L, 4L, NA_integer_, NA_integer_),
+             info = "starts_from_1_cpp: integer adjust with NA and range clipping")
+
+# NA integer stays NA
+out_na <- starts_from_1_cpp(data.frame(a = NA_integer_), c("a"), 1L, list(1L), list(5L))
+expect_true(is.na(out_na[1]), info = "starts_from_1_cpp: NA integer stays NA")
+
+# factor column path (uses fct_to_int_cpp internally)
+out_fac <- starts_from_1_cpp(tbl, c("f"), 1L, list(1L), list(3L))
+expect_equal(out_fac, c(1L, 2L, 3L, 1L),
+             info = "starts_from_1_cpp: factor column converted to 1-based codes")
+
+# unsupported column type (character) -> error
+expect_error(starts_from_1_cpp(tbl, c("ch"), 1L, list(1L), list(3L)),
+             pattern = "integer or a factor",
+             info = "starts_from_1_cpp: character column rejected")
+
+# -----------------------------------------------------------------------------
+# dtsubset
+# -----------------------------------------------------------------------------
+DT <- data.table::data.table(x = 1:5, y = letters[1:5], z = 11:15)
+
+expect_error(dtsubset(NULL, 1L, 1L), pattern = "NULL",
+             info = "dtsubset: NULL x")
+expect_error(dtsubset(DT, NULL, 1L), pattern = "NULL",
+             info = "dtsubset: NULL rows")
+expect_error(dtsubset(DT, 1L, NULL), pattern = "NULL",
+             info = "dtsubset: NULL cols")
+expect_error(dtsubset(data.frame(x = 1:5), 1L, 1L), pattern = "must be a data.table",
+             info = "dtsubset: x not a data.table")
+expect_error(dtsubset(DT, 1.0, 1L), pattern = "Row indices must be integer",
+             info = "dtsubset: rows not integer")
+expect_error(dtsubset(DT, 1L, 1.0), pattern = "Column indices must be integer",
+             info = "dtsubset: cols not integer")
+expect_error(dtsubset(DT, integer(0), 1L), pattern = "Row indices vector is empty",
+             info = "dtsubset: empty rows")
+expect_error(dtsubset(DT, 1L, integer(0)), pattern = "Column indices vector is empty",
+             info = "dtsubset: empty cols")
+expect_error(dtsubset(DT, 1L, NA_integer_), pattern = "cannot contain NA",
+             info = "dtsubset: NA column index")
+expect_error(dtsubset(DT, 1L, 99L), pattern = "out of bounds",
+             info = "dtsubset: column index out of range")
+expect_error(dtsubset(DT, 1L, 0L), pattern = "out of bounds",
+             info = "dtsubset: column index below range")
+
+# happy path: select rows 1,3 and columns 1,3
+res <- dtsubset(DT, c(1L, 3L), c(1L, 3L))
+expect_equal(res[[1]], c(1L, 3L), info = "dtsubset: subset returns selected rows (col 1)")
+expect_equal(res[[2]], c(11L, 13L), info = "dtsubset: subset returns selected rows (col 3)")

--- a/inst/tinytest/test-distr_cpp_branches.R
+++ b/inst/tinytest/test-distr_cpp_branches.R
@@ -1,0 +1,212 @@
+# Tests targeting otherwise-uncovered C++ branches in src/distr_<NAME>.cpp:
+#   1. parameter-validation `stop()` branches in fd/fp/fq, exercised with
+#      log_p = TRUE (and lower_tail = FALSE where relevant), and
+#   2. the compiled fr<NAME> random generators, which at the R level are
+#      shadowed by pure-R versions in R/rng_distr.R and are therefore only
+#      reachable via .Call().
+# These do NOT depend on gamlss.dist.
+
+library(CKutils)
+library(tinytest)
+
+# --------------------------------------------------------------------------
+# 1. Validation / log_p / lower_tail error branches in fq / fp / fd
+# --------------------------------------------------------------------------
+
+## ---- NBI (mu, sigma) ----
+# fqNBI has a SEPARATE validation loop guarded by `if (log_p)`.
+expect_error(fqNBI(0.5, mu = -1, sigma = 1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqNBI(0.5, mu =  1, sigma = 0, log_p = TRUE), "sigma must be greater than 0")
+# fqNBI non-log_p branch (p out of range, and invalid params)
+expect_error(fqNBI(-0.1, mu = 1, sigma = 1), "p must be >=0 and <=1")
+expect_error(fqNBI(0.5, mu = -1, sigma = 1), "mu must be greater than 0")
+expect_error(fqNBI(0.5, mu =  1, sigma = 0), "sigma must be greater than 0")
+# fqNBI lower_tail = FALSE combined with log_p = TRUE (normal path)
+expect_silent(fqNBI(log(0.5), mu = 2, sigma = 1, lower_tail = FALSE, log_p = TRUE))
+# fdNBI / fpNBI validation (unconditional loops)
+expect_error(fdNBI(0, mu = -1, sigma = 1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fdNBI(0, mu =  1, sigma = 0, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fdNBI(-1, mu = 1, sigma = 1), "x must be >=0")
+expect_error(fpNBI(0, mu = -1, sigma = 1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpNBI(0, mu =  1, sigma = 0, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpNBI(-1, mu = 1, sigma = 1), "q must be >=0")
+
+## ---- ZINBI (mu, sigma, nu in (0,1)) ----
+expect_error(fdZINBI(0, mu = -1, sigma = 1, nu = 0.1, TRUE), "mu must be greater than 0")
+expect_error(fdZINBI(0, mu = 1, sigma = 0, nu = 0.1, TRUE), "sigma must be greater than 0")
+expect_error(fdZINBI(0, mu = 1, sigma = 1, nu = 1.5, TRUE), "nu must be between 0 and 1")
+expect_error(fdZINBI(-1, mu = 1, sigma = 1, nu = 0.1), "x must be >=0")
+expect_error(fpZINBI(0, mu = -1, sigma = 1, nu = 0.1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpZINBI(0, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpZINBI(0, mu = 1, sigma = 1, nu = 0, log_p = TRUE), "nu must be between 0 and 1")
+expect_error(fpZINBI(-1, mu = 1, sigma = 1, nu = 0.1), "q must be >=0")
+expect_error(fqZINBI(0.5, mu = -1, sigma = 1, nu = 0.1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqZINBI(0.5, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqZINBI(0.5, mu = 1, sigma = 1, nu = 2, log_p = TRUE), "nu must be between 0 and 1")
+expect_error(fqZINBI(-0.1, mu = 1, sigma = 1, nu = 0.1), "p must be >=0 and <=1")
+
+## ---- ZANBI (mu, sigma, nu in (0,1)) ----
+expect_error(fdZANBI(0, mu = -1, sigma = 1, nu = 0.1, TRUE), "mu must be greater than 0")
+expect_error(fdZANBI(0, mu = 1, sigma = 0, nu = 0.1, TRUE), "sigma must be greater than 0")
+expect_error(fdZANBI(0, mu = 1, sigma = 1, nu = 1.5, TRUE), "nu must be between 0 and 1")
+expect_error(fdZANBI(-1, mu = 1, sigma = 1, nu = 0.1), "x must be >=0")
+expect_error(fpZANBI(0, mu = -1, sigma = 1, nu = 0.1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpZANBI(0, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpZANBI(0, mu = 1, sigma = 1, nu = 0, log_p = TRUE), "nu must be between 0 and 1")
+expect_error(fpZANBI(-1, mu = 1, sigma = 1, nu = 0.1), "q must be >=0")
+expect_error(fqZANBI(0.5, mu = -1, sigma = 1, nu = 0.1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqZANBI(0.5, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqZANBI(0.5, mu = 1, sigma = 1, nu = 2, log_p = TRUE), "nu must be between 0 and 1")
+expect_error(fqZANBI(-0.1, mu = 1, sigma = 1, nu = 0.1), "p must be >=0 and <=1")
+
+## ---- BNB (mu, sigma, nu > 0) ----
+expect_error(fdBNB(0, mu = -1, sigma = 1, nu = 1, TRUE), "mu must be greater than 0")
+expect_error(fdBNB(0, mu = 1, sigma = 0, nu = 1, TRUE), "sigma must be greater than 0")
+expect_error(fdBNB(0, mu = 1, sigma = 1, nu = 0, TRUE), "nu must be greater than 0")
+expect_error(fdBNB(-1, mu = 1, sigma = 1, nu = 1), "x must be >=0")
+expect_error(fpBNB(0, mu = -1, sigma = 1, nu = 1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpBNB(0, mu = 1, sigma = 0, nu = 1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpBNB(0, mu = 1, sigma = 1, nu = 0, log_p = TRUE), "nu must be greater than 0")
+expect_error(fpBNB(-1, mu = 1, sigma = 1, nu = 1), "q must be >=0")
+expect_error(fqBNB(0.5, mu = -1, sigma = 1, nu = 1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqBNB(0.5, mu = 1, sigma = 0, nu = 1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqBNB(0.5, mu = 1, sigma = 1, nu = 0, log_p = TRUE), "nu must be greater than 0")
+expect_error(fqBNB(-0.1, mu = 1, sigma = 1, nu = 1), "p must be >=0 and <=1")
+
+## ---- SICHEL (mu, sigma, nu); fd/fp/fq validate mu & sigma ----
+expect_error(fdSICHEL(0, mu = -1, sigma = 1, nu = -0.5, log_p = TRUE), "mu must be greater than 0")
+expect_error(fdSICHEL(0, mu = 1, sigma = 0, nu = -0.5, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fdSICHEL(-1, mu = 1, sigma = 1, nu = -0.5), "x must be >=0")
+expect_error(fpSICHEL(0, mu = -1, sigma = 1, nu = -0.5, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpSICHEL(0, mu = 1, sigma = 0, nu = -0.5, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpSICHEL(-1, mu = 1, sigma = 1, nu = -0.5), "q must be >=0")
+# fqSICHEL has a SEPARATE `if (log_p)` validation loop.
+expect_error(fqSICHEL(0.5, mu = -1, sigma = 1, nu = -0.5, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqSICHEL(0.5, mu = 1, sigma = 0, nu = -0.5, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqSICHEL(0.5, mu = -1, sigma = 1, nu = -0.5), "mu must be greater than 0")
+expect_error(fqSICHEL(0.5, mu = 1, sigma = 0, nu = -0.5), "sigma must be greater than 0")
+
+## ---- ZISICHEL (mu, sigma, nu, tau in (0,1)); fp/fq validate mu, sigma, tau ----
+expect_error(fpZISICHEL(0, mu = -1, sigma = 1, nu = -0.5, tau = 0.1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpZISICHEL(0, mu = 1, sigma = 0, nu = -0.5, tau = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpZISICHEL(0, mu = 1, sigma = 1, nu = -0.5, tau = 2, log_p = TRUE), "tau must be between 0 and 1")
+expect_error(fpZISICHEL(-1, mu = 1, sigma = 1, nu = -0.5, tau = 0.1), "q must be >=0")
+# fqZISICHEL has a SEPARATE `if (log_p)` validation loop.
+expect_error(fqZISICHEL(0.5, mu = -1, sigma = 1, nu = -0.5, tau = 0.1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqZISICHEL(0.5, mu = 1, sigma = 0, nu = -0.5, tau = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqZISICHEL(0.5, mu = 1, sigma = 1, nu = -0.5, tau = 2, log_p = TRUE), "tau must be between 0 and 1")
+expect_error(fqZISICHEL(0.5, mu = -1, sigma = 1, nu = -0.5, tau = 0.1), "mu must be greater than 0")
+expect_error(fqZISICHEL(0.5, mu = 1, sigma = 0, nu = -0.5, tau = 0.1), "sigma must be greater than 0")
+expect_error(fqZISICHEL(0.5, mu = 1, sigma = 1, nu = -0.5, tau = 2), "tau must be between 0 and 1")
+
+## ---- DEL (mu, sigma, nu in (0,1)) ----
+# fdDEL density-log arg is positional (log_); pass positionally as 5th arg.
+expect_error(fdDEL(0L, mu = -1, sigma = 1, nu = 0.1, TRUE), "mu must be greater than 0")
+expect_error(fdDEL(0L, mu = 1, sigma = 0, nu = 0.1, TRUE), "sigma must be greater than 0")
+expect_error(fdDEL(0L, mu = 1, sigma = 1, nu = 1.5, TRUE), "nu must be between 0 and 1")
+expect_error(fdDEL(-1L, mu = 1, sigma = 1, nu = 0.1), "x must be >=0")
+expect_error(fpDEL(0L, mu = -1, sigma = 1, nu = 0.1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpDEL(0L, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpDEL(0L, mu = 1, sigma = 1, nu = 0, log_p = TRUE), "nu must be between 0 and 1")
+expect_error(fpDEL(-1L, mu = 1, sigma = 1, nu = 0.1), "q must be >=0")
+expect_error(fqDEL(0.5, mu = -1, sigma = 1, nu = 0.1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqDEL(0.5, mu = 1, sigma = 0, nu = 0.1, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqDEL(0.5, mu = 1, sigma = 1, nu = 2, log_p = TRUE), "nu must be between 0 and 1")
+# fqDEL p-range validation after exp(log_p) transform
+expect_error(fqDEL(2, mu = 1, sigma = 1, nu = 0.1), "p must be between 0 and 1")
+
+## ---- DPO (mu, sigma) ----
+expect_error(fdDPO(0L, mu = -1, sigma = 1, TRUE), "mu must be greater than 0")
+expect_error(fdDPO(0L, mu = 1, sigma = 0, TRUE), "sigma must be greater than 0")
+expect_error(fdDPO(-1L, mu = 1, sigma = 1), "x must be >=0")
+expect_error(fpDPO(0L, mu = -1, sigma = 1, lower_tail = FALSE, log_p = TRUE), "mu must be greater than 0")
+expect_error(fpDPO(0L, mu = 1, sigma = 0, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fpDPO(-1L, mu = 1, sigma = 1), "q must be >=0")
+expect_error(fqDPO(0.5, mu = -1, sigma = 1, log_p = TRUE), "mu must be greater than 0")
+expect_error(fqDPO(0.5, mu = 1, sigma = 0, log_p = TRUE), "sigma must be greater than 0")
+expect_error(fqDPO(2, mu = 1, sigma = 1), "p must be between 0 and 1")
+
+## ---- BCT (mu, sigma, nu, tau); validates mu, sigma, tau ----
+expect_error(fdBCT(1, mu = -1, sigma = 1, nu = 1, tau = 5, TRUE), "mu must be positive")
+expect_error(fdBCT(1, mu = 1, sigma = 0, nu = 1, tau = 5, TRUE), "sigma must be positive")
+expect_error(fdBCT(1, mu = 1, sigma = 1, nu = 1, tau = 0, TRUE), "tau must be positive")
+expect_error(fdBCT(-1, mu = 1, sigma = 1, nu = 1, tau = 5), "x must be >=0")
+expect_error(fpBCT(1, mu = -1, sigma = 1, nu = 1, tau = 5, lower_tail = FALSE, log_p = TRUE), "mu must be positive")
+expect_error(fpBCT(1, mu = 1, sigma = 0, nu = 1, tau = 5, log_p = TRUE), "sigma must be positive")
+expect_error(fpBCT(1, mu = 1, sigma = 1, nu = 1, tau = 0, log_p = TRUE), "tau must be positive")
+expect_error(fpBCT(-1, mu = 1, sigma = 1, nu = 1, tau = 5), "q must be >=0")
+# For fqBCT the p-range check runs after the exp() transform, so use log(0.5)
+# to keep p valid and reach the mu/sigma/tau checks.
+expect_error(fqBCT(log(0.5), mu = -1, sigma = 1, nu = 1, tau = 5, log_p = TRUE), "mu must be positive")
+expect_error(fqBCT(log(0.5), mu = 1, sigma = 0, nu = 1, tau = 5, log_p = TRUE), "sigma must be positive")
+expect_error(fqBCT(log(0.5), mu = 1, sigma = 1, nu = 1, tau = 0, log_p = TRUE), "tau must be positive")
+expect_error(fqBCT(2, mu = 1, sigma = 1, nu = 1, tau = 5), "p must be between 0 and 1")
+
+## ---- BCPEo (mu, sigma, nu, tau); validates mu, sigma, tau ----
+expect_error(fdBCPEo(1, mu = -1, sigma = 1, nu = 1, tau = 2, TRUE), "mu must be positive")
+expect_error(fdBCPEo(1, mu = 1, sigma = 0, nu = 1, tau = 2, TRUE), "sigma must be positive")
+expect_error(fdBCPEo(1, mu = 1, sigma = 1, nu = 1, tau = 0, TRUE), "tau must be positive")
+expect_error(fdBCPEo(-1, mu = 1, sigma = 1, nu = 1, tau = 2), "x must be >=0")
+expect_error(fpBCPEo(1, mu = -1, sigma = 1, nu = 1, tau = 2, lower_tail = FALSE, log_p = TRUE), "mu must be positive")
+expect_error(fpBCPEo(1, mu = 1, sigma = 0, nu = 1, tau = 2, log_p = TRUE), "sigma must be positive")
+expect_error(fpBCPEo(1, mu = 1, sigma = 1, nu = 1, tau = 0, log_p = TRUE), "tau must be positive")
+expect_error(fpBCPEo(-1, mu = 1, sigma = 1, nu = 1, tau = 2), "q must be positive")
+expect_error(fqBCPEo(0.5, mu = -1, sigma = 1, nu = 1, tau = 2, log_p = TRUE), "mu must be positive")
+expect_error(fqBCPEo(0.5, mu = 1, sigma = 0, nu = 1, tau = 2, log_p = TRUE), "sigma must be positive")
+expect_error(fqBCPEo(0.5, mu = 1, sigma = 1, nu = 1, tau = 0, log_p = TRUE), "tau must be positive")
+expect_error(fqBCPEo(2, mu = 1, sigma = 1, nu = 1, tau = 2), "p must be between 0 and 1")
+
+# --------------------------------------------------------------------------
+# 2. Compiled fr<NAME> random generators (reached only via .Call, since the
+#    R-level names are shadowed by pure-R versions in R/rng_distr.R).
+# --------------------------------------------------------------------------
+
+## ---- frNBI(n, mu, sigma) ----
+expect_error(.Call("_CKutils_frNBI", 0L, 2.0, 1.0), "n must be a positive integer")
+expect_error(.Call("_CKutils_frNBI", 5L, -1.0, 1.0), "mu must be greater than 0")
+expect_error(.Call("_CKutils_frNBI", 5L, 2.0, 0.0), "sigma must be greater than 0")
+set.seed(42)
+# Normal sigma -> negative-binomial branch of frNBI_scalar
+x_nbi <- .Call("_CKutils_frNBI", 100L, 2.0, 1.0)
+expect_equal(length(x_nbi), 100L)
+expect_true(all(is.finite(x_nbi)))
+expect_true(all(x_nbi >= 0))
+expect_true(is.integer(x_nbi))
+# Tiny sigma (< 1e-4) -> Poisson-approximation branch of frNBI_scalar
+set.seed(42)
+x_nbi_pois <- .Call("_CKutils_frNBI", 100L, 2.0, 1e-6)
+expect_equal(length(x_nbi_pois), 100L)
+expect_true(all(is.finite(x_nbi_pois)))
+expect_true(all(x_nbi_pois >= 0))
+
+## ---- frZINBI(n, mu, sigma, nu) ----
+expect_error(.Call("_CKutils_frZINBI", 0L, 2.0, 1.0, 0.1), "n must be a positive integer")
+expect_error(.Call("_CKutils_frZINBI", 5L, -1.0, 1.0, 0.1), "mu must be greater than 0")
+expect_error(.Call("_CKutils_frZINBI", 5L, 2.0, 0.0, 0.1), "sigma must be greater than 0")
+expect_error(.Call("_CKutils_frZINBI", 5L, 2.0, 1.0, 1.5), "nu must be between 0 and 1")
+set.seed(7)
+# Large nu so the u < nu (zero-inflation) branch of frZINBI_scalar is hit,
+# and the else (frNBI_scalar) branch is also exercised.
+x_zinbi <- .Call("_CKutils_frZINBI", 200L, 2.0, 1.0, 0.5)
+expect_equal(length(x_zinbi), 200L)
+expect_true(all(is.finite(x_zinbi)))
+expect_true(all(x_zinbi >= 0))
+expect_true(is.integer(x_zinbi))
+expect_true(any(x_zinbi == 0))   # zero-inflation branch reached
+expect_true(any(x_zinbi > 0))    # NBI branch reached
+
+## ---- frZANBI(n, mu, sigma, nu) ----
+expect_error(.Call("_CKutils_frZANBI", 0L, 2.0, 1.0, 0.1), "n must be a positive integer")
+expect_error(.Call("_CKutils_frZANBI", 5L, -1.0, 1.0, 0.1), "mu must be greater than 0")
+expect_error(.Call("_CKutils_frZANBI", 5L, 2.0, 0.0, 0.1), "sigma must be greater than 0")
+expect_error(.Call("_CKutils_frZANBI", 5L, 2.0, 1.0, 0.0), "nu must be between 0 and 1")
+set.seed(99)
+# nu = 0.5 hits both the zero-altered (u < nu) branch and the truncated-NBI
+# rejection branch (do { x = frNBI_scalar } while (x == 0)).
+x_zanbi <- .Call("_CKutils_frZANBI", 200L, 2.0, 1.0, 0.5)
+expect_equal(length(x_zanbi), 200L)
+expect_true(all(is.finite(x_zanbi)))
+expect_true(all(x_zanbi >= 0))
+expect_true(is.integer(x_zanbi))
+expect_true(any(x_zanbi == 0))   # zero-altered branch reached
+expect_true(any(x_zanbi > 0))    # truncated-NBI branch reached

--- a/inst/tinytest/test-dropbox_path.R
+++ b/inst/tinytest/test-dropbox_path.R
@@ -1,0 +1,46 @@
+# Tests for get_dropbox_path() on the non-Windows (Linux/macOS) code path.
+# get_dropbox_path() reads "~/.dropbox/info.json". To avoid clobbering a real
+# Dropbox install, we only run when that directory does not already exist, and
+# we always clean up what we create.
+
+dropbox_dir <- path.expand("~/.dropbox")
+info_json   <- file.path(dropbox_dir, "info.json")
+
+if (.Platform$OS.type == "windows") {
+  exit_file("get_dropbox_path Linux-path tests skipped on Windows")
+}
+if (file.exists(dropbox_dir)) {
+  exit_file("~/.dropbox already exists - skip to avoid clobbering a real install")
+}
+
+dir.create(dropbox_dir)
+
+# --- personal + business paths present --------------------------------------
+writeLines(
+  jsonlite::toJSON(
+    list(personal = list(path = "/tmp/ck_dropbox_personal"),
+         business = list(path = "/tmp/ck_dropbox_business")),
+    auto_unbox = TRUE),
+  info_json)
+
+expect_equal(get_dropbox_path(),
+             normalizePath("/tmp/ck_dropbox_personal/", mustWork = FALSE),
+             info = "get_dropbox_path personal (default)")
+expect_equal(get_dropbox_path(type = "business"),
+             normalizePath("/tmp/ck_dropbox_business/", mustWork = FALSE),
+             info = "get_dropbox_path business")
+# pathtail is appended
+expect_equal(get_dropbox_path("sub/dir"),
+             normalizePath("/tmp/ck_dropbox_personal/sub/dir", mustWork = FALSE),
+             info = "get_dropbox_path appends pathtail")
+
+# --- info.json present but no path field -> 'cannot be located' error --------
+writeLines(jsonlite::toJSON(list(other = list(x = 1)), auto_unbox = TRUE),
+           info_json)
+expect_error(get_dropbox_path(),
+             pattern = "cannot be located",
+             info = "get_dropbox_path errors when no path is recorded")
+
+# cleanup (tinytest evaluates top-level expressions individually, so on.exit()
+# would fire too early; remove the scratch directory explicitly at the end).
+unlink(dropbox_dir, recursive = TRUE)

--- a/inst/tinytest/test-gamlss_helpers.R
+++ b/inst/tinytest/test-gamlss_helpers.R
@@ -1,0 +1,187 @@
+# Tests for gamlss/polr/reldist helper functions in R/misc_functions.R:
+#   validate_gamlss, guess_gamlss, guess_polr, crossval_gamlss,
+#   reldist_diagnostics
+
+if (!requireNamespace("gamlss", quietly = TRUE)) {
+  exit_file("gamlss not available - skipping gamlss helper tests")
+}
+
+suppressMessages({
+  library(data.table)
+  library(gamlss)
+})
+
+
+# Open a pdf device so plotting functions do not need an interactive device.
+grDevices::pdf(tempfile(fileext = ".pdf"))
+on.exit(grDevices::dev.off(), add = TRUE)
+
+set.seed(42L)
+
+# ---------------------------------------------------------------------------
+# Build a small dataset and fit a tiny gamlss NO model
+# ---------------------------------------------------------------------------
+n <- 60L
+dat <- data.table(
+  year = rep(c(1L, 2L), each = n / 2L),
+  agegrp = runif(n, 20, 60)
+)
+dat[, bmi := 25 + 0.05 * agegrp + rnorm(n, 0, 2)]
+
+mod <- suppressWarnings(gamlss::gamlss(
+  bmi ~ agegrp,
+  sigma.fo = ~1,
+  family = gamlss.dist::NO(),
+  data = dat,
+  control = gamlss::gamlss.control(n.cyc = 5L, trace = FALSE)
+))
+
+expect_true(inherits(mod, "gamlss"), info = "gamlss model fitted")
+
+# ---------------------------------------------------------------------------
+# validate_gamlss
+# ---------------------------------------------------------------------------
+vg <- validate_gamlss(copy(dat), mod, mc = 3L, orig_data = copy(dat))
+expect_true(is.data.table(vg), info = "validate_gamlss returns data.table")
+expect_true("type" %in% names(vg), info = "validate_gamlss has type column")
+expect_true("bmi" %in% names(vg), info = "validate_gamlss has outcome column")
+expect_true(all(c("Observed", "Modelled") %in% unique(vg$type)),
+  info = "validate_gamlss has both Observed and Modelled rows")
+# n observed rows + mc * n modelled rows
+expect_equal(nrow(vg), n + 3L * n, info = "validate_gamlss row count")
+expect_true(all(is.finite(vg[type == "Modelled", bmi])),
+  info = "validate_gamlss modelled outcome finite")
+# parameter columns dropped on exit
+expect_false("mu" %in% names(vg), info = "validate_gamlss drops mu param col")
+
+# default orig_data branch (orig_data = dtb)
+vg2 <- validate_gamlss(copy(dat), mod, mc = 2L)
+expect_equal(nrow(vg2), n + 2L * n, info = "validate_gamlss default orig_data")
+
+# ---------------------------------------------------------------------------
+# crossval_gamlss
+# ---------------------------------------------------------------------------
+dat_cv <- copy(dat)
+dat_cv[, rank := runif(.N)]   # column named "rank" (default colnam)
+cv <- crossval_gamlss(dat_cv, mod, orig_data = dat_cv, colnam = "rank")
+expect_true(is.list(cv), info = "crossval_gamlss returns list")
+expect_true(all(c("observed", "predicted") %in% names(cv)),
+  info = "crossval_gamlss has observed and predicted")
+expect_equal(length(cv$observed), nrow(dat_cv),
+  info = "crossval_gamlss observed length")
+expect_equal(length(cv$predicted), nrow(dat_cv),
+  info = "crossval_gamlss predicted length")
+expect_true(all(is.finite(cv$predicted)),
+  info = "crossval_gamlss predicted finite")
+
+# Exercise the p==0 / p==1 clamping branches
+dat_cv2 <- copy(dat)
+dat_cv2[, rank := c(0, 1, runif(.N - 2L))]
+cv2 <- crossval_gamlss(dat_cv2, mod, orig_data = dat_cv2, colnam = "rank")
+expect_true(all(is.finite(cv2$predicted)),
+  info = "crossval_gamlss clamps p==0/p==1")
+
+# default orig_data branch
+cv3 <- crossval_gamlss(copy(dat_cv), mod, colnam = "rank")
+expect_true(is.list(cv3), info = "crossval_gamlss default orig_data")
+
+# ---------------------------------------------------------------------------
+# guess_gamlss
+#  - guess_gamlss splits the unique predictor rows by `dtu$year`, so the model
+#    formula MUST contain `year` as a predictor (otherwise dtu has no `year`).
+#  - needs a `rank_<y>` column (here rank_bmi) holding percentiles in (0, 1).
+#  - modifies `dtb` by reference: the outcome column (bmi) is replaced by the
+#    predicted quantile, and the working columns (p, mu, sigma) are dropped.
+# ---------------------------------------------------------------------------
+mod_y <- suppressWarnings(gamlss::gamlss(
+  bmi ~ agegrp + year,
+  sigma.fo = ~1,
+  family = gamlss.dist::NO(),
+  data = dat,
+  control = gamlss::gamlss.control(n.cyc = 5L, trace = FALSE)
+))
+
+dat_g <- copy(dat)
+dat_g[, rank_bmi := runif(.N, 0.01, 0.99)]
+
+gg <- copy(dat_g)
+res_g <- guess_gamlss(gg, mod_y, orig_data = copy(dat_g), nc = 1L)
+# returns the modified data.table (invisibly) and edits by reference
+expect_true(is.data.table(gg), info = "guess_gamlss keeps dtb a data.table")
+expect_true(all(is.finite(gg$bmi)),
+  info = "guess_gamlss fills outcome with finite predicted quantiles")
+expect_false("p" %in% names(gg), info = "guess_gamlss drops the working p column")
+expect_false("mu" %in% names(gg), info = "guess_gamlss drops gamlss param columns")
+expect_true("rank_bmi" %in% names(gg), info = "guess_gamlss leaves rank_ column intact")
+
+# default orig_data branch (orig_data = gamlss_obj$data): gamlss stores $data as
+# a plain data.frame, so this hits the is.data.table(orig_data) guard.
+err2 <- tryCatch(
+  guess_gamlss(copy(dat_g), mod_y, nc = 1L),
+  error = function(e) conditionMessage(e)
+)
+expect_true(is.character(err2) && grepl("orig_data", err2),
+  info = "guess_gamlss default orig_data hits is.data.table guard")
+
+# ---------------------------------------------------------------------------
+# guess_polr (MASS::polr)
+# ---------------------------------------------------------------------------
+if (requireNamespace("MASS", quietly = TRUE) &&
+    requireNamespace("matrixStats", quietly = TRUE)) {
+
+  set.seed(7L)
+  np <- 120L
+  xp <- runif(np, -2, 2)
+  # ordered outcome with 3 levels driven by xp
+  lp <- 1.5 * xp + rnorm(np)
+  ycat <- cut(lp, breaks = quantile(lp, c(0, 1 / 3, 2 / 3, 1)),
+    include.lowest = TRUE, labels = c("low", "mid", "high"))
+  pdat <- data.frame(y = factor(ycat, ordered = TRUE), x = xp)
+
+  pmod <- MASS::polr(y ~ x, data = pdat, Hess = TRUE)
+  expect_true(inherits(pmod, "polr"), info = "polr model fitted")
+
+  pdt <- as.data.table(pdat)
+  pdt[, rank_y := runif(.N, 0.01, 0.99)]
+  res_polr <- guess_polr(pdt, pmod)
+  # function modifies dtb in place; y column replaced with integer codes
+  expect_true("y" %in% names(pdt), info = "guess_polr keeps outcome col")
+  expect_true(is.numeric(pdt$y), info = "guess_polr outcome numeric")
+  expect_true(all(is.finite(pdt$y)), info = "guess_polr outcome finite")
+  q <- length(pmod$zeta)
+  expect_true(all(pdt$y >= 0L & pdt$y <= q),
+    info = "guess_polr categories within range")
+  expect_false("p" %in% names(pdt), info = "guess_polr drops p column")
+} else {
+  cat("MASS/matrixStats not available - skipping guess_polr test\n")
+}
+
+# ---------------------------------------------------------------------------
+# reldist_diagnostics (uses reldist package; produces plots)
+# ---------------------------------------------------------------------------
+if (requireNamespace("reldist", quietly = TRUE)) {
+  set.seed(99L)
+  m <- 400L
+  reference <- rnorm(m, 0, 1)
+  comparison <- rnorm(m, 0.4, 1.1)
+  reference_wt <- rep(1, m)
+  comparison_wt <- rep(1, m)
+
+  rd <- suppressWarnings(reldist_diagnostics(
+    comparison = comparison,
+    reference = reference,
+    comparison_wt = comparison_wt,
+    reference_wt = reference_wt,
+    main = "test",
+    smooth = 0.35,
+    discrete = FALSE
+  ))
+  expect_true(is.data.table(rd), info = "reldist_diagnostics returns data.table")
+  expect_equal(nrow(rd), 6L, info = "reldist_diagnostics 6 summary rows")
+  expect_true(all(c("Summary statistics", "Measure", "p-value") %in% names(rd)),
+    info = "reldist_diagnostics expected columns")
+  expect_true(is.numeric(rd[["Measure"]]),
+    info = "reldist_diagnostics Measure numeric")
+} else {
+  cat("reldist not available - skipping reldist_diagnostics test\n")
+}

--- a/inst/tinytest/test-lookup_extra.R
+++ b/inst/tinytest/test-lookup_extra.R
@@ -1,0 +1,137 @@
+# Tinytest script: extra coverage for R/lookup_dt.R
+# Targets previously-uncovered branches in lookup_dt() and its helpers.
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+suppressMessages(library(data.table))
+
+# --- Line 198: non-integer/non-numeric (character) lookup key, validity OFF ---
+# With check_lookup_tbl_validity = FALSE the type check inside the cardinality
+# loop is reached: a key column that is neither factor, integer, nor numeric.
+tbl_char <- data.table(k = c("a", "b"), x = 1:2)
+lt_char  <- data.table(k = c("a", "b"), val = c("p", "q"))
+setkey(lt_char, k)
+expect_error(
+  lookup_dt(copy(tbl_char), lt_char, check_lookup_tbl_validity = FALSE),
+  pattern = "must be integer or numeric",
+  info = "lookup_dt: character lookup key triggers 'must be integer or numeric'"
+)
+
+# --- Line 203: NA values in a numeric lookup key, validity OFF ---
+tbl_na <- data.table(k = c(1, 2), x = 1:2)
+lt_na  <- data.table(k = c(1, NA_real_), val = c("p", "q"))
+setkey(lt_na, k)
+expect_error(
+  lookup_dt(copy(tbl_na), lt_na, check_lookup_tbl_validity = FALSE),
+  pattern = "contains NA values",
+  info = "lookup_dt: NA in numeric lookup key triggers 'contains NA values'"
+)
+
+# --- Line 211: integer-overflow / range-too-large guard, validity OFF ---
+# Span between min and max exceeds .Machine$integer.max.
+tbl_ovf <- data.table(k = c(1L, 2L), x = 1:2)
+lt_ovf  <- data.table(k = c(-.Machine$integer.max, 1), val = c("p", "q"))
+setkeyv(lt_ovf, "k")
+expect_error(
+  lookup_dt(copy(tbl_ovf), lt_ovf, check_lookup_tbl_validity = FALSE),
+  pattern = "range too large",
+  info = "lookup_dt: huge key range triggers 'range too large'"
+)
+
+# --- Line 190: factor key with different levels in tbl vs lookup_tbl, validity ON ---
+# lookup_tbl is internally valid (2 levels, 2 rows) so is_valid_lookup_tbl passes,
+# but tbl carries an extra level so the in-loop identical(levels) check fires.
+lt_lvl  <- data.table(k = factor(c("X", "Y"), levels = c("X", "Y")),
+                      val = c("v1", "v2"))
+setkey(lt_lvl, k)
+tbl_lvl <- data.table(k = factor("X", levels = c("X", "Y", "Z")), x = 1L)
+expect_error(
+  lookup_dt(tbl_lvl, lt_lvl, check_lookup_tbl_validity = TRUE),
+  pattern = "different levels",
+  info = "lookup_dt: differing factor levels triggers 'has different levels'"
+)
+
+# --- Lines 248-252: C++ index-calculation error handler ---
+# tbl key column is character while lookup key is a factor; with validity OFF the
+# levels check is skipped, so starts_from_1_cpp is called and throws, exercising
+# the tryCatch handler that augments the message with column-type diagnostics.
+lt_cpp  <- data.table(k = factor(c("X", "Y")), val = c("a", "b"))
+setkey(lt_cpp, k)
+tbl_cpp <- data.table(k = c("X", "Y"), x = 1:2)
+expect_error(
+  lookup_dt(copy(tbl_cpp), lt_cpp, check_lookup_tbl_validity = FALSE),
+  pattern = "Error in C\\+\\+ index calculation",
+  info = "lookup_dt: C++ failure routed through diagnostic tryCatch handler"
+)
+
+# --- Lines 256-258: warning when computed row indices contain NA, validity ON ---
+# Integer lookup is internally valid; a tbl value outside the key range maps to an
+# NA index, triggering both the message (line 219) and the NA warning (line 257).
+lt_naidx  <- CJ(k = 1:2)
+lt_naidx[, v := letters[1:2]]
+setkey(lt_naidx, k)
+tbl_naidx <- data.table(k = c(1L, 2L, 5L))
+expect_warning(
+  suppressMessages(
+    lookup_dt(copy(tbl_naidx), lt_naidx, check_lookup_tbl_validity = TRUE, merge = TRUE)
+  ),
+  pattern = "row indices are NA",
+  info = "lookup_dt: NA row index produces 'row indices are NA' warning"
+)
+# And the merged result keeps an NA for the unmatched row.
+res_naidx <- suppressMessages(suppressWarnings(
+  lookup_dt(copy(tbl_naidx), lt_naidx, check_lookup_tbl_validity = TRUE, merge = TRUE)
+))
+expect_identical(res_naidx$v, c("a", "b", NA_character_),
+                 info = "lookup_dt: unmatched out-of-range row yields NA value")
+
+# --- merge = FALSE path with the same NA-index scenario (return-only branch) ---
+res_naidx_f <- suppressMessages(suppressWarnings(
+  lookup_dt(copy(tbl_naidx), lt_naidx, check_lookup_tbl_validity = FALSE, merge = FALSE)
+))
+expect_identical(names(res_naidx_f), "v",
+                 info = "lookup_dt (merge=FALSE): returns only the value column")
+expect_identical(res_naidx_f$v, c("a", "b", NA_character_),
+                 info = "lookup_dt (merge=FALSE): correct values incl NA for unmatched")
+
+# --- is_valid_lookup_tbl: double (non-integer) key column triggers type error ---
+dlt <- data.table(k = c(1, 2), v = c("a", "b"))
+setkey(dlt, k)
+expect_error(
+  is_valid_lookup_tbl(dlt, "k"),
+  pattern = "must be of type integer",
+  info = "is_valid_lookup_tbl: double key column rejected as non-integer"
+)
+
+# --- is_valid_lookup_tbl: valid integer single-key table returns TRUE ---
+ilt <- data.table(k = 1:3, v = letters[1:3])
+setkey(ilt, k)
+expect_true(is_valid_lookup_tbl(ilt, "k"),
+            info = "is_valid_lookup_tbl: valid consecutive integer key returns TRUE")
+
+# --- is_valid_lookup_tbl: fixkey = TRUE sets the key and emits a message ---
+fk <- CJ(id = 1L:2L, cat = factor(letters[1:2]), sorted = FALSE)
+fk[, v := runif(.N)]
+expect_message(
+  is_valid_lookup_tbl(fk, c("id", "cat"), fixkey = TRUE),
+  info = "is_valid_lookup_tbl (fixkey=TRUE): emits key-setting message"
+)
+expect_identical(key(fk), c("cat", "id"),
+                 info = "is_valid_lookup_tbl (fixkey=TRUE): key actually set")
+
+# --- set_lookup_tbl_key: 'year' priority and basic operation ---
+sk <- data.table(year = 2020:2022, id = 1:3, v = runif(3))
+ret <- set_lookup_tbl_key(sk, c("id", "year"))
+expect_identical(key(sk), c("year", "id"),
+                 info = "set_lookup_tbl_key: 'year' prioritised in key order")
+expect_true(is.data.table(ret),
+            info = "set_lookup_tbl_key: returns the data.table (invisibly)")
+
+# --- set_lookup_tbl_key: error paths ---
+expect_error(set_lookup_tbl_key(list(a = 1), "a"),
+             pattern = "should be a data.table",
+             info = "set_lookup_tbl_key: non-data.table input errors")
+expect_error(set_lookup_tbl_key(data.table(a = 1), character(0)),
+             pattern = "keycols argument is missing",
+             info = "set_lookup_tbl_key: empty keycols errors")

--- a/inst/tinytest/test-misc_cpp.R
+++ b/inst/tinytest/test-misc_cpp.R
@@ -1,0 +1,454 @@
+# Branch / edge-case tests for the exported C++ functions in src/misc_functions.cpp
+# Complements test-misc_functions.R (happy paths) by focusing on the
+# currently-untested branches: empty / all-NA / single-element inputs,
+# na_rm TRUE/FALSE, inplace/byref TRUE/FALSE, bound swaps, recycling,
+# NA handling and stop() error branches.
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+suppressMessages(library(data.table))
+
+# =============================================================================
+# fquantile
+# =============================================================================
+
+# Empty probs -> length-0 numeric, regardless of x
+expect_equal(fquantile(c(1, 2, 3), numeric(0)), numeric(0),
+             info = "fquantile empty probs returns numeric(0)")
+expect_equal(length(fquantile(c(1, 2, 3), numeric(0))), 0L,
+             info = "fquantile empty probs length 0")
+
+# Empty x -> NA for every prob
+res_empty_x <- fquantile(numeric(0), c(0.25, 0.5, 0.75))
+expect_equal(length(res_empty_x), 3L, info = "fquantile empty x length matches probs")
+expect_true(all(is.na(res_empty_x)), info = "fquantile empty x all NA")
+
+# All-NA x -> NA for every prob (this branch fires before na_rm)
+res_allna <- fquantile(c(NA_real_, NA_real_), c(0.25, 0.5))
+expect_equal(length(res_allna), 2L, info = "fquantile all-NA length matches probs")
+expect_true(all(is.na(res_allna)), info = "fquantile all-NA returns all NA")
+
+# na_rm = TRUE removing NAs and leaving a single element -> that value everywhere
+res_single <- fquantile(c(NA, 7, NA), c(0.1, 0.9), na_rm = TRUE)
+expect_equal(res_single, c(7, 7), info = "fquantile single non-NA element repeats value")
+
+# na_rm = FALSE with NA present (but not all NA) keeps NA -> NA result
+res_no_rm <- fquantile(c(1, 2, NA, 4, 5), c(0.5), na_rm = FALSE)
+expect_true(is.na(res_no_rm), info = "fquantile na_rm=FALSE propagates NA")
+
+# Normal interpolation (type 7) on integer-spaced data
+expect_equal(fquantile(c(1, 2, 3, 4, 5), c(0.25, 0.5, 0.75)), c(2, 3, 4),
+             info = "fquantile normal interpolation correct")
+# Non-trivial interpolation (index falls between observations)
+expect_equal(fquantile(c(0, 10), c(0.25)), 2.5,
+             info = "fquantile interpolates between two points")
+
+# =============================================================================
+# fquantile_byid
+# =============================================================================
+
+# Empty x -> list of length 1 + length(q), with empty id slot
+res_bid_emptyx <- fquantile_byid(numeric(0), c(0.5), character(0))
+expect_true(is.list(res_bid_emptyx), info = "fquantile_byid empty x returns list")
+expect_equal(length(res_bid_emptyx), 2L, info = "fquantile_byid empty x list length 1+q")
+expect_equal(length(res_bid_emptyx[[1]]), 0L, info = "fquantile_byid empty x empty id slot")
+
+# Empty q -> list of length 1, just the empty id slot
+res_bid_emptyq <- fquantile_byid(c(1, 2, 3), numeric(0), c("A", "A", "A"))
+expect_true(is.list(res_bid_emptyq), info = "fquantile_byid empty q returns list")
+expect_equal(length(res_bid_emptyq), 1L, info = "fquantile_byid empty q list length 1")
+
+# Length mismatch between x and id -> stop()
+expect_error(fquantile_byid(c(1, 2, 3), c(0.5), c("A", "B")),
+             pattern = "Length of 'x' and 'id' must match",
+             info = "fquantile_byid length mismatch errors")
+
+# Multiple groups, rounding = FALSE
+res_bid <- fquantile_byid(c(1, 2, 3, 4, 5, 6), c(0.5),
+                          c("A", "A", "A", "B", "B", "B"), rounding = FALSE)
+expect_equal(res_bid[[1]], c("A", "B"), info = "fquantile_byid multi-group ids")
+expect_equal(res_bid[[2]], c(2, 5), info = "fquantile_byid multi-group medians")
+
+# Multiple groups, rounding = TRUE (medians are integers here, so round is no-op
+# numerically but exercises the rounding branch)
+res_bid_round <- fquantile_byid(c(1, 2, 4, 4, 5, 7), c(0.5),
+                                c("A", "A", "A", "B", "B", "B"), rounding = TRUE)
+expect_equal(res_bid_round[[1]], c("A", "B"), info = "fquantile_byid rounding ids")
+expect_equal(res_bid_round[[2]], round(c(2, 5), 0),
+             info = "fquantile_byid rounding=TRUE rounds quantiles")
+
+# Single group
+res_bid_single <- fquantile_byid(c(2, 4, 6), c(0.5), c("G", "G", "G"))
+expect_equal(res_bid_single[[1]], "G", info = "fquantile_byid single group id")
+expect_equal(res_bid_single[[2]], 4, info = "fquantile_byid single group median")
+
+# =============================================================================
+# count_if / prop_if
+# =============================================================================
+
+# Without NA
+expect_equal(count_if(c(TRUE, FALSE, TRUE, TRUE)), 3L, info = "count_if no NA")
+expect_equal(prop_if(c(TRUE, FALSE, TRUE, TRUE)), 0.75, info = "prop_if no NA")
+
+# With NA, na_rm = FALSE: NA counts toward denominator for prop_if but is not TRUE
+expect_equal(count_if(c(TRUE, NA, FALSE, TRUE), na_rm = FALSE), 2L,
+             info = "count_if NA na_rm=FALSE counts only TRUE")
+expect_equal(prop_if(c(TRUE, NA, FALSE, TRUE), na_rm = FALSE), 0.5,
+             info = "prop_if NA na_rm=FALSE keeps NA in denominator")
+
+# With NA, na_rm = TRUE: NA dropped before counting
+expect_equal(count_if(c(TRUE, NA, FALSE, TRUE), na_rm = TRUE), 2L,
+             info = "count_if NA na_rm=TRUE")
+expect_equal(prop_if(c(TRUE, NA, FALSE, TRUE), na_rm = TRUE), 2 / 3,
+             info = "prop_if NA na_rm=TRUE drops NA from denominator")
+
+# count_if on empty vector -> 0
+expect_equal(count_if(logical(0)), 0L, info = "count_if empty -> 0")
+# prop_if on empty vector -> 0/0 = NaN
+expect_true(is.nan(prop_if(logical(0))), info = "prop_if empty -> NaN")
+
+# =============================================================================
+# fclamp
+# =============================================================================
+
+# inplace = FALSE (default): returns clamped copy, leaves input untouched
+x_fc <- c(-1, 0.5, 2)
+expect_equal(fclamp(x_fc, a = 0, b = 1), c(0, 0.5, 1),
+             info = "fclamp inplace=FALSE clamps")
+expect_equal(x_fc, c(-1, 0.5, 2), info = "fclamp inplace=FALSE leaves input unchanged")
+
+# a > b swap branch (bounds get swapped to [0, 1])
+expect_equal(fclamp(c(-1, 0.5, 2), a = 1, b = 0), c(0, 0.5, 1),
+             info = "fclamp swaps a>b bounds")
+
+# NA element preserved as NA
+expect_equal(fclamp(c(NA, 0.5, 2), a = 0, b = 1), c(NA, 0.5, 1),
+             info = "fclamp keeps NA")
+
+# Recycling of a / b against longer x
+expect_equal(fclamp(c(-5, 5, 0.5), a = 0, b = c(1, 2, 3)), c(0, 2, 0.5),
+             info = "fclamp recycles scalar a against vector b")
+
+# inplace = TRUE: mutates x by reference
+x_fc_ip <- c(-1, 0.5, 2)
+ret_ip <- fclamp(x_fc_ip, a = 0, b = 1, inplace = TRUE)
+expect_equal(x_fc_ip, c(0, 0.5, 1), info = "fclamp inplace=TRUE mutates input")
+expect_equal(ret_ip, c(0, 0.5, 1), info = "fclamp inplace=TRUE returns clamped vector")
+
+# inplace = TRUE with length mismatch after recycling -> stop()
+x_fc_bad <- c(0.5)
+expect_error(fclamp(x_fc_bad, a = c(0, 0, 0), b = c(1, 1, 1), inplace = TRUE),
+             pattern = "In-place operation requires consistent vector lengths",
+             info = "fclamp inplace length mismatch errors")
+
+# =============================================================================
+# fclamp_int
+# =============================================================================
+
+# inplace = FALSE, a > b swap, and NA element
+expect_equal(fclamp_int(c(-1L, 3L, NA, 7L), a = 5L, b = 0L),
+             c(0L, 3L, NA, 5L),
+             info = "fclamp_int swaps bounds and keeps NA (inplace=FALSE)")
+
+# inplace = TRUE mutates input
+x_fci <- c(-1L, 3L, 7L)
+fclamp_int(x_fci, a = 0L, b = 5L, inplace = TRUE)
+expect_equal(x_fci, c(0L, 3L, 5L), info = "fclamp_int inplace=TRUE mutates input")
+
+# inplace = FALSE leaves input unchanged
+x_fci2 <- c(-1L, 3L, 7L)
+out_fci2 <- fclamp_int(x_fci2, a = 0L, b = 5L, inplace = FALSE)
+expect_equal(out_fci2, c(0L, 3L, 5L), info = "fclamp_int inplace=FALSE clamps")
+expect_equal(x_fci2, c(-1L, 3L, 7L), info = "fclamp_int inplace=FALSE unchanged input")
+
+# =============================================================================
+# fequal
+# =============================================================================
+
+# Equal within tolerance, with NA dropped by na_omit
+expect_true(as.logical(fequal(c(1.0, NA, 1.00001), 0.001)),
+            info = "fequal equal-within-tol with NA")
+# Not equal -> FALSE
+expect_false(as.logical(fequal(c(1.0, NA, 2.0), 0.001)),
+             info = "fequal unequal returns FALSE")
+# All-NA -> na_omit empties -> loop skipped -> TRUE (vacuously equal)
+expect_true(as.logical(fequal(c(NA_real_, NA_real_), 0.001)),
+            info = "fequal all-NA returns TRUE (vacuous)")
+# Exactly equal values
+expect_true(as.logical(fequal(c(3.0, 3.0, 3.0), 0.0)),
+            info = "fequal identical values, zero tol")
+
+# =============================================================================
+# fnormalise
+# =============================================================================
+
+# Normal case scales to [0, 1]
+expect_equal(fnormalise(c(10, 20, 30)), c(0, 0.5, 1), info = "fnormalise scales 0-1")
+# NA: min/max computed on na_omit; NA element stays NA, others scaled
+res_fn_na <- fnormalise(c(2, NA, 6, 10))
+expect_equal(res_fn_na, c(0, NA, 0.5, 1), info = "fnormalise keeps NA, scales rest")
+
+# =============================================================================
+# lin_interpolation
+# =============================================================================
+
+expect_equal(lin_interpolation(c(1.5), c(1), c(2), c(10), c(20)), 15,
+             info = "lin_interpolation midpoint")
+expect_equal(lin_interpolation(c(1.5, 2.5), c(1, 2), c(2, 3), c(10, 20), c(20, 30)),
+             c(15, 25), info = "lin_interpolation vectorised")
+# Extrapolation beyond x1 follows the same line
+expect_equal(lin_interpolation(c(3), c(1), c(2), c(10), c(20)), 30,
+             info = "lin_interpolation extrapolates linearly")
+
+# =============================================================================
+# carry_forward (byref TRUE/FALSE, empty, NA, person boundaries)
+# =============================================================================
+
+# Empty input
+expect_equal(length(carry_forward(integer(0), logical(0), 1L, FALSE)), 0L,
+             info = "carry_forward empty input")
+
+# byref = FALSE returns new vector and does NOT mutate the original
+x_cf <- c(1L, 0L, 2L, 0L, 1L)
+pid_cf <- c(TRUE, FALSE, FALSE, TRUE, FALSE)
+out_cf <- carry_forward(x_cf, pid_cf, 1L, FALSE)
+expect_equal(out_cf, c(1L, 1L, 1L, 0L, 1L), info = "carry_forward byref=FALSE result")
+expect_equal(x_cf, c(1L, 0L, 2L, 0L, 1L), info = "carry_forward byref=FALSE no mutation")
+
+# byref = TRUE mutates in place
+x_cf_ip <- c(1L, 0L, 2L, 0L, 1L)
+carry_forward(x_cf_ip, pid_cf, 1L, TRUE)
+expect_equal(x_cf_ip, c(1L, 1L, 1L, 0L, 1L), info = "carry_forward byref=TRUE mutates")
+
+# NA in x at a position: position with NA pid/prev-x is skipped, but carry
+# continues once a valid value is set. Here x(0)=1==y propagates forward.
+x_cf_na <- c(1L, NA, 1L, 0L)
+expect_equal(carry_forward(x_cf_na, c(TRUE, FALSE, FALSE, FALSE), 1L, FALSE),
+             c(1L, 1L, 1L, 1L), info = "carry_forward NA handling / propagation")
+
+# NA in pid_mrk skips that position
+x_cf_pidna <- c(1L, 0L, 0L)
+expect_equal(carry_forward(x_cf_pidna, c(TRUE, NA, FALSE), 1L, FALSE),
+             c(1L, 0L, 0L), info = "carry_forward NA pid_mrk skips position")
+
+# Person boundary (pid TRUE) stops the carry
+x_cf_b <- c(1L, 0L)
+expect_equal(carry_forward(x_cf_b, c(TRUE, TRUE), 1L, FALSE), c(1L, 0L),
+             info = "carry_forward person boundary blocks carry")
+
+# =============================================================================
+# carry_forward_incr (recur TRUE/FALSE, byref TRUE/FALSE, empty, NA)
+# =============================================================================
+
+# Empty input
+expect_equal(length(carry_forward_incr(integer(0), logical(0), FALSE, 1L, FALSE)), 0L,
+             info = "carry_forward_incr empty input")
+
+pid_cfi <- c(TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
+             TRUE, FALSE, FALSE, FALSE, FALSE, FALSE)
+x_cfi <- c(0L, 0L, 1L, 0L, 1L, 1L, 0L, 1L, 1L, 0L, 1L, 1L)
+
+# Non-recursive: increment continuously once previous >= y
+out_nonrec <- carry_forward_incr(x_cfi, pid_cfi, FALSE, 1L, FALSE)
+expect_equal(out_nonrec, c(0L, 0L, 1L, 2L, 3L, 4L, 0L, 1L, 2L, 3L, 4L, 5L),
+             info = "carry_forward_incr non-recursive")
+
+# Recursive: increment only when both current >= y AND previous >= y
+out_rec <- carry_forward_incr(x_cfi, pid_cfi, TRUE, 1L, FALSE)
+expect_equal(out_rec, c(0L, 0L, 1L, 0L, 1L, 2L, 0L, 1L, 2L, 0L, 1L, 2L),
+             info = "carry_forward_incr recursive")
+
+# byref = TRUE mutates in place (non-recursive)
+x_cfi_ip <- c(x_cfi)
+carry_forward_incr(x_cfi_ip, pid_cfi, FALSE, 1L, TRUE)
+expect_equal(x_cfi_ip, c(0L, 0L, 1L, 2L, 3L, 4L, 0L, 1L, 2L, 3L, 4L, 5L),
+             info = "carry_forward_incr byref=TRUE non-recursive mutates")
+
+# byref = TRUE mutates in place (recursive)
+x_cfi_ip2 <- c(x_cfi)
+carry_forward_incr(x_cfi_ip2, pid_cfi, TRUE, 1L, TRUE)
+expect_equal(x_cfi_ip2, c(0L, 0L, 1L, 0L, 1L, 2L, 0L, 1L, 2L, 0L, 1L, 2L),
+             info = "carry_forward_incr byref=TRUE recursive mutates")
+
+# NA handling, non-recursive: NA in previous element skips position i
+x_cfi_na <- c(NA, 0L, 0L)
+expect_equal(carry_forward_incr(x_cfi_na, c(TRUE, FALSE, FALSE), FALSE, 1L, FALSE),
+             c(NA, 0L, 0L),
+             info = "carry_forward_incr non-recursive NA in prev skips")
+
+# NA handling, recursive: NA in current element skips
+x_cfi_na2 <- c(1L, 2L, NA, 2L)
+expect_equal(carry_forward_incr(x_cfi_na2, c(TRUE, FALSE, FALSE, FALSE), TRUE, 1L, FALSE),
+             c(1L, 2L, NA, 2L),
+             info = "carry_forward_incr recursive NA in current skips")
+
+# =============================================================================
+# carry_backward_decr (empty, NA, threshold, person boundary, no-negatives)
+# =============================================================================
+
+# Empty input
+expect_equal(length(carry_backward_decr(integer(0), logical(0), 0L)), 0L,
+             info = "carry_backward_decr empty input")
+
+# Basic backward decrement (default threshold y = 0)
+x_cb <- c(0L, 0L, 5L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L)
+pid_cb <- c(TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
+            TRUE, FALSE, FALSE, FALSE, FALSE, FALSE)
+expect_equal(carry_backward_decr(x_cb, pid_cb),
+             c(3L, 4L, 5L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L),
+             info = "carry_backward_decr default threshold")
+
+# Higher threshold suppresses propagation
+expect_equal(carry_backward_decr(x_cb, pid_cb, 6L), x_cb,
+             info = "carry_backward_decr threshold above values leaves unchanged")
+
+# Never goes below 0
+x_cb_neg <- c(0L, 1L, 1L, 1L, 0L)
+pid_cb_neg <- c(TRUE, FALSE, FALSE, TRUE, FALSE)
+expect_equal(carry_backward_decr(x_cb_neg, pid_cb_neg),
+             c(0L, 0L, 1L, 1L, 0L),
+             info = "carry_backward_decr clamps at 0")
+
+# NA in x at position i is skipped
+x_cb_na <- c(0L, NA, 3L, 0L)
+expect_equal(carry_backward_decr(x_cb_na, c(TRUE, FALSE, FALSE, FALSE)),
+             c(1L, 2L, 3L, 0L),
+             info = "carry_backward_decr skips NA at position i")
+
+# =============================================================================
+# mk_new_simulant_markers (empty, single, NA, boundaries)
+# =============================================================================
+
+expect_equal(length(mk_new_simulant_markers(integer(0))), 0L,
+             info = "mk_new_simulant_markers empty input")
+expect_equal(mk_new_simulant_markers(1L), TRUE,
+             info = "mk_new_simulant_markers single element TRUE")
+expect_equal(mk_new_simulant_markers(c(1L, 1L, 2L, 3L, 3L)),
+             c(TRUE, FALSE, TRUE, TRUE, FALSE),
+             info = "mk_new_simulant_markers basic boundaries")
+# NA treated as new simulant; the value following an NA is also a new simulant
+expect_equal(mk_new_simulant_markers(c(1L, 1L, NA, NA, 2L)),
+             c(TRUE, FALSE, TRUE, TRUE, TRUE),
+             info = "mk_new_simulant_markers NA handling")
+# First element NA -> previous_pid NA branch
+expect_equal(mk_new_simulant_markers(c(NA, 5L, 5L)),
+             c(TRUE, TRUE, FALSE),
+             info = "mk_new_simulant_markers leading NA")
+
+# =============================================================================
+# identify_longdead (empty, single, NA, boundaries)
+# =============================================================================
+
+expect_equal(length(identify_longdead(integer(0), logical(0))), 0L,
+             info = "identify_longdead empty input")
+expect_equal(identify_longdead(5L, TRUE), FALSE,
+             info = "identify_longdead single element")
+expect_equal(identify_longdead(c(0L, 1L, 0L, 1L, 0L),
+                               c(TRUE, FALSE, FALSE, TRUE, FALSE)),
+             c(FALSE, FALSE, TRUE, FALSE, TRUE),
+             info = "identify_longdead basic")
+# NA in pid or prev-x skips position
+expect_equal(identify_longdead(c(1L, 1L, 1L),
+                               c(TRUE, NA, FALSE)),
+             c(FALSE, FALSE, TRUE),
+             info = "identify_longdead NA pid skips")
+expect_equal(identify_longdead(c(NA, 1L, 1L),
+                               c(TRUE, FALSE, FALSE)),
+             c(FALSE, FALSE, TRUE),
+             info = "identify_longdead NA prev-x skips")
+
+# =============================================================================
+# identify_invitees (empty, NA -> NA, eligibility / frequency / probability)
+# =============================================================================
+
+expect_equal(length(identify_invitees(integer(0), integer(0), numeric(0),
+                                       integer(0), logical(0))), 0L,
+             info = "identify_invitees empty input")
+
+# Deterministic probability 1 with eligible + frequency met -> all invited
+inv_all <- identify_invitees(c(1L, 1L, 1L),
+                             c(0L, 0L, 0L),
+                             c(1.0, 1.0, 1.0),
+                             c(0L, 0L, 0L),
+                             c(TRUE, FALSE, FALSE))
+expect_equal(inv_all, c(1L, 1L, 1L),
+             info = "identify_invitees prob=1, eligible, freq met -> invite")
+
+# Probability 0 -> never invited
+inv_none <- identify_invitees(c(1L, 1L, 1L),
+                              c(0L, 0L, 0L),
+                              c(0.0, 0.0, 0.0),
+                              c(0L, 0L, 0L),
+                              c(TRUE, FALSE, FALSE))
+expect_equal(inv_none, c(0L, 0L, 0L),
+             info = "identify_invitees prob=0 -> no invites")
+
+# Ineligible -> never invited even at prob 1
+inv_inelig <- identify_invitees(c(0L, 0L, 0L),
+                                c(0L, 0L, 0L),
+                                c(1.0, 1.0, 1.0),
+                                c(0L, 0L, 0L),
+                                c(TRUE, FALSE, FALSE))
+expect_equal(inv_inelig, c(0L, 0L, 0L),
+             info = "identify_invitees ineligible -> no invites")
+
+# prev_inv = 1 resets counter to 0; with freq 1 the next year is blocked
+inv_freq <- identify_invitees(c(1L, 1L),
+                              c(0L, 1L),
+                              c(1.0, 1.0),
+                              c(5L, 5L),
+                              c(TRUE, FALSE))
+# Year 1: new person, counter=1000 >= freq -> invite (1)
+# Year 2: prev_inv==1 -> counter=0 < freq(5) -> not invited
+expect_equal(inv_freq, c(1L, 0L),
+             info = "identify_invitees frequency interval respected")
+
+# NA in any critical input -> NA output for that position
+inv_na <- identify_invitees(c(1L, NA),
+                            c(0L, 0L),
+                            c(1.0, 1.0),
+                            c(1L, 1L),
+                            c(TRUE, FALSE))
+expect_true(is.na(inv_na[2]), info = "identify_invitees NA input -> NA output")
+
+# =============================================================================
+# hc_effect (empty, NA, boundaries) -- deterministic prob endpoints
+# =============================================================================
+
+expect_equal(length(hc_effect(integer(0), 0.5, logical(0))), 0L,
+             info = "hc_effect empty input")
+# prob = 1: effect continues from a previous 1 (within person)
+expect_equal(hc_effect(c(0L, 1L, 0L, 1L, 0L), 1.0,
+                       c(TRUE, FALSE, FALSE, TRUE, FALSE)),
+             c(0L, 1L, 1L, 1L, 1L),
+             info = "hc_effect prob=1 continues effect")
+# prob = 0: never continues
+expect_equal(hc_effect(c(0L, 1L, 0L, 1L, 0L), 0.0,
+                       c(TRUE, FALSE, FALSE, TRUE, FALSE)),
+             c(0L, 1L, 0L, 1L, 0L),
+             info = "hc_effect prob=0 leaves unchanged")
+# NA in prev element skips
+expect_equal(hc_effect(c(1L, NA, 0L), 1.0, c(TRUE, FALSE, FALSE)),
+             c(1L, NA, 0L),
+             info = "hc_effect NA prev skips")
+
+# =============================================================================
+# antilogit (both numerically-stable branches, symmetry, endpoints)
+# =============================================================================
+
+expect_equal(antilogit(0), 0.5, info = "antilogit(0) = 0.5")
+# x > 0 branch
+expect_equal(antilogit(2), exp(2) / (1 + exp(2)), tolerance = 1e-12,
+             info = "antilogit positive branch")
+# x <= 0 branch
+expect_equal(antilogit(-2), exp(-2) / (1 + exp(-2)), tolerance = 1e-12,
+             info = "antilogit non-positive branch")
+# Symmetry
+expect_equal(antilogit(-3), 1 - antilogit(3), tolerance = 1e-12,
+             info = "antilogit symmetry")
+# Numerical stability at extremes
+expect_true(is.finite(antilogit(700)) && is.finite(antilogit(-700)),
+            info = "antilogit finite at extremes")
+expect_true(antilogit(700) <= 1 && antilogit(-700) >= 0,
+            info = "antilogit bounded [0,1] at extremes")

--- a/inst/tinytest/test-misc_cpp_branches.R
+++ b/inst/tinytest/test-misc_cpp_branches.R
@@ -1,0 +1,54 @@
+# Supplementary tests for branches of the carry_* / carry_backward_decr C++
+# helpers in src/misc_functions.cpp that need specific byref/recur/NA inputs.
+
+# carry_forward, byref = TRUE, with NA in pid_mrk and NA in the previous value
+# -> exercises the in-place NA-skip `continue` branch.
+x1 <- c(7L, 7L, 7L, 7L)
+pm1 <- c(TRUE, NA, FALSE, FALSE)         # NA marker at position 2
+r1  <- carry_forward(x1, pm1, y = 7L, byref = TRUE)
+expect_equal(x1, r1, info = "carry_forward byref returns the (mutated) input")
+expect_true(is.integer(r1), info = "carry_forward byref NA-skip path runs")
+
+# NA at x(i-1) makes carry_forward skip (continue) and leave x(i) untouched.
+x1b <- c(NA_integer_, 5L, 5L)            # NA in x(0); i=1 -> skip
+pm1b <- c(TRUE, FALSE, FALSE)
+carry_forward(x1b, pm1b, y = 5L, byref = TRUE)
+expect_true(is.na(x1b[1]), info = "carry_forward byref NA at x(i-1) -> skip")
+
+# carry_forward_incr, byref = TRUE, recur = TRUE, NA-skip branch (NA marker)
+xr <- c(5L, 6L, NA_integer_, 7L)
+pmr <- c(TRUE, FALSE, FALSE, NA)         # NA marker at last position -> skip
+carry_forward_incr(xr, pmr, recur = TRUE, y = 5L, byref = TRUE)
+expect_true(is.integer(xr), info = "carry_forward_incr byref recur NA-skip runs")
+
+# carry_forward_incr, byref = TRUE, recur = FALSE: NA at x(i-1) -> skip,
+# otherwise continuous increment.
+xi <- c(NA_integer_, 5L, 5L)
+pmi <- c(TRUE, FALSE, FALSE)
+carry_forward_incr(xi, pmi, recur = FALSE, y = 5L, byref = TRUE)
+# i=1: prev is NA -> skip; i=2: prev(5)>=5 -> x(2)=6
+expect_true(is.na(xi[1]), info = "carry_forward_incr non-recur NA at x(i-1) -> skip")
+expect_equal(xi[3], 6L, info = "carry_forward_incr non-recur increments")
+
+# carry_backward_decr: NA-skip (continue), the new-person back-fill branch, and
+# the negative-clamp branch (out(i) < 0 -> 0).
+xb  <- c(3L, 0L, NA_integer_, 2L, 1L)
+pmb <- c(TRUE, FALSE, FALSE, TRUE, FALSE)
+rb  <- carry_backward_decr(xb, pmb, y = 0L)
+expect_true(is.integer(rb) && length(rb) == 5L,
+            info = "carry_backward_decr returns same-length integer vector")
+
+# negative-clamp branch: values that would go below zero are clamped up to 0.
+# The clamp applies to processed positions (i = n-1 .. 1); index 0 is not visited.
+xneg <- c(-5L, -5L, -5L)
+pmneg <- c(TRUE, FALSE, FALSE)
+rneg <- carry_backward_decr(xneg, pmneg, y = -10L)
+expect_true(any(rneg == 0L), info = "carry_backward_decr clamps negatives to 0")
+
+# fclamp with inplace = TRUE AND a > b: exercises the in-place bound-swap branch.
+xc <- c(-1, 0.5, 2, 5)
+r_inplace_swap <- fclamp(xc, a = 3, b = 1, inplace = TRUE)   # a > b -> swapped to [1, 3]
+expect_equal(xc, c(1, 1, 2, 3),
+             info = "fclamp inplace with a > b swaps bounds and clamps in place")
+expect_equal(r_inplace_swap, c(1, 1, 2, 3),
+             info = "fclamp inplace returns the clamped vector")

--- a/inst/tinytest/test-misc_extra.R
+++ b/inst/tinytest/test-misc_extra.R
@@ -1,0 +1,256 @@
+# Extra tests targeting branch coverage of misc_functions.R:
+#   agegrp_name, replace_from_table, to_agegrp, get_pcloud_path, arrow_in
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+suppressMessages(library(data.table))
+set.seed(42)
+
+# =============================================================================
+# get_pcloud_path
+# =============================================================================
+
+pc <- get_pcloud_path()
+expect_true(is.character(pc), info = "get_pcloud_path returns character")
+expect_equal(length(pc), 1L, info = "get_pcloud_path returns scalar")
+expect_true(nchar(pc) > 0L, info = "get_pcloud_path non-empty")
+
+pc_tail <- get_pcloud_path("subdir")
+expect_true(is.character(pc_tail), info = "get_pcloud_path(tail) is character")
+expect_equal(length(pc_tail), 1L, info = "get_pcloud_path(tail) scalar")
+expect_true(grepl("subdir", pc_tail), info = "pathtail appended to pcloud path")
+
+# =============================================================================
+# agegrp_name
+# =============================================================================
+
+# grp_width > 1, open band ((tail(x,1)-1) != max_age): NN+ naming, no <1
+g_open <- agegrp_name(20, 79, 5, grp_lessthan_1 = FALSE)
+expect_equal(
+  g_open,
+  c("20-24", "25-29", "30-34", "35-39", "40-44", "45-49",
+    "50-54", "55-59", "60-64", "65-69", "70-74", "75-79"),
+  info = "open band w5 no open-ended needed (tail-1 == max here is 79? check)"
+)
+
+# Documented: 20-79 actually has 75-79 closing exactly; use 20-80 for the NN+ band
+g_openplus <- agegrp_name(20, 80, 5, grp_lessthan_1 = FALSE)
+expect_true("80+" %in% g_openplus, info = "open-ended 80+ band created")
+expect_equal(g_openplus[length(g_openplus)], "80+", info = "last band is 80+")
+
+# grp_width > 1, closed band (tail(x,1)-1 == max_age) -> head drop, no NN+
+g_closed <- agegrp_name(20, 79, 5)
+expect_false(any(grepl("\\+", g_closed)), info = "closed band has no open-ended")
+
+# grp_lessthan_1 TRUE with min_age == 0, open band
+g_lt1_open <- agegrp_name(0, 80, 10, TRUE)
+expect_equal(g_lt1_open[1], "<1", info = "<1 first band when grp_lessthan_1 & min_age==0")
+expect_equal(g_lt1_open[2], "01-09", info = "second band relabeled to 01-NN")
+expect_equal(g_lt1_open[length(g_lt1_open)], "80+", info = "open-ended last band with <1")
+
+# grp_lessthan_1 TRUE with min_age == 0, closed band (tail-1 == max)
+g_lt1_closed <- agegrp_name(0, 9, 5, TRUE)
+expect_equal(g_lt1_closed, c("<1", "01-04", "05-09"), info = "<1 closed band")
+
+# grp_width == 1 branch (else branch)
+g_w1 <- agegrp_name(20, 25, 1)
+expect_equal(g_w1, c("20", "21", "22", "23", "24", "25"),
+             info = "grp_width == 1 yields single-year labels")
+
+# match_input TRUE, else path (grp_lessthan_1 FALSE), open band (tail-1 != max)
+g_m_open_else <- agegrp_name(20, 30, 5, FALSE, TRUE)
+expect_equal(length(g_m_open_else), 11L,
+             info = "match_input open else: 5+5 repeats + 1 open band")
+expect_equal(g_m_open_else[1], "20-24", info = "match open else first")
+expect_equal(g_m_open_else[length(g_m_open_else)], "30+", info = "match open else last")
+
+# match_input TRUE, else path, open band with match_input_max_age extension
+g_m_open_else_mia <- agegrp_name(20, 30, 5, FALSE, TRUE, 32)
+expect_equal(length(g_m_open_else_mia), 13L,
+             info = "match_input_max_age extends open band repeats")
+expect_equal(sum(g_m_open_else_mia == "30+"), 3L,
+             info = "open band repeated to match_input_max_age")
+
+# match_input TRUE, else path, closed band (tail-1 == max)
+g_m_closed_else <- agegrp_name(20, 29, 5, FALSE, TRUE)
+expect_equal(length(g_m_closed_else), 10L,
+             info = "match_input closed else: each band repeated grp_width")
+expect_false(any(grepl("\\+", g_m_closed_else)),
+             info = "match closed else no open-ended")
+
+# match_input TRUE, grp_lessthan_1 & min_age==0 path, open band (tail-1 != max)
+g_m_open_lt1 <- agegrp_name(0, 30, 5, TRUE, TRUE)
+expect_equal(g_m_open_lt1[1], "<1", info = "match <1 open: first is <1")
+expect_equal(g_m_open_lt1[length(g_m_open_lt1)], "30+",
+             info = "match <1 open: last is 30+")
+expect_equal(sum(g_m_open_lt1 == "01-04"), 4L,
+             info = "match <1 open: 01-04 band has 4 entries (first overwritten by <1)")
+expect_equal(sum(g_m_open_lt1 == "05-09"), 5L,
+             info = "match <1 open: full interior band repeated grp_width times")
+
+# match_input TRUE, grp_lessthan_1 & min_age==0 path, closed band (tail-1 == max)
+g_m_closed_lt1 <- agegrp_name(0, 29, 5, TRUE, TRUE)
+expect_equal(g_m_closed_lt1[1], "<1", info = "match <1 closed: first is <1")
+expect_false(any(grepl("\\+", g_m_closed_lt1)),
+             info = "match <1 closed: no open-ended band")
+expect_equal(length(g_m_closed_lt1), 30L,
+             info = "match <1 closed: length covers each single year")
+
+# stopifnot validation failures
+expect_error(agegrp_name(min_age = -1, max_age = 80), info = "min_age < 0 errors")
+expect_error(agegrp_name(min_age = 50, max_age = 30), info = "max_age <= min_age errors")
+expect_error(agegrp_name(min_age = 0, max_age = 80, grp_width = 0),
+             info = "grp_width < 1 errors")
+expect_error(agegrp_name(min_age = 0, max_age = 80, match_input_max_age = 70),
+             info = "match_input_max_age < max_age errors")
+expect_error(agegrp_name(min_age = 0, max_age = 0), info = "max_age == 0 errors")
+
+# =============================================================================
+# replace_from_table
+# =============================================================================
+
+base_dt <- data.table(
+  a = 1:5,
+  b = seq(1, 2.2, 0.3),
+  d = letters[1:5]
+)
+base_dt[, e := factor(a, labels = LETTERS[1:5])]
+
+# same-class, by reference (newcolname NULL)
+r1 <- replace_from_table(copy(base_dt), "a", 3L, -11L)
+expect_equal(r1$a, c(1L, 2L, -11L, 4L, 5L), info = "same-class byref replace")
+expect_equal(names(r1), names(base_dt), info = "column order preserved byref")
+
+# same-class, into a new column
+r2 <- replace_from_table(copy(base_dt), "a", 3L, -11L, "newcol")
+expect_true("newcol" %in% names(r2), info = "new column created")
+expect_equal(r2$newcol, c(1L, 2L, -11L, 4L, 5L), info = "new column holds replaced values")
+expect_equal(r2$a, base_dt$a, info = "original column unchanged with newcolname")
+
+# same-class many-to-one (length(from) > length(to)) -> message branch + byref
+expect_message(
+  replace_from_table(copy(base_dt), "a", 1:3, 3L),
+  pattern = "matched many to few",
+  info = "many-to-few message"
+)
+r3 <- suppressMessages(replace_from_table(copy(base_dt), "a", 1:3, 3L))
+expect_equal(r3$a, c(3L, 3L, 3L, 4L, 5L), info = "many-to-one values correct")
+
+# different-class coercion, by reference (emits coercion message)
+expect_message(
+  replace_from_table(copy(base_dt), "b", 1.3, "a"),
+  pattern = "coerced to",
+  info = "diff-class byref coercion message"
+)
+r4 <- suppressMessages(replace_from_table(copy(base_dt), "b", 1.3, "a"))
+expect_true(is.character(r4$b), info = "diff-class byref column coerced to character")
+expect_equal(r4$b, c("1", "a", "1.6", "1.9", "2.2"), info = "diff-class byref values")
+expect_equal(names(r4), names(base_dt), info = "diff-class byref preserves col order")
+
+# different-class coercion, into a new column (no coercion message in this branch)
+r5 <- replace_from_table(copy(base_dt), "b", 1.3, "a", "nc")
+expect_true("nc" %in% names(r5), info = "diff-class new column created")
+expect_equal(r5$nc, c("1", "a", "1.6", "1.9", "2.2"), info = "diff-class newcol values")
+expect_equal(r5$b, base_dt$b, info = "diff-class original column unchanged")
+
+# factor column replacement
+r6 <- replace_from_table(copy(base_dt), "e", "B", "J")
+expect_true("J" %in% as.character(r6$e), info = "factor replacement works")
+expect_equal(as.character(r6$e), c("A", "J", "C", "D", "E"), info = "factor values correct")
+
+# error: newcolname already exists
+expect_error(
+  replace_from_table(copy(base_dt), "a", 3L, -11L, "b"),
+  pattern = "already exists",
+  info = "error when newcolname exists"
+)
+
+# error: not a data.table
+expect_error(replace_from_table(as.data.frame(base_dt), "a", 3L, -11L),
+             info = "error on non-data.table")
+# error: colname not in dtb
+expect_error(replace_from_table(copy(base_dt), "zzz", 1, 2),
+             info = "error on missing colname")
+# error: length(from) < length(to)
+expect_error(replace_from_table(copy(base_dt), "a", 1L, c(1L, 2L)),
+             info = "error when from shorter than to")
+
+# =============================================================================
+# to_agegrp
+# =============================================================================
+
+# default options, factor output
+t1 <- to_agegrp(data.table(age = 0:99))
+expect_true("agegrp" %in% names(t1), info = "agegrp column created")
+expect_true(is.factor(t1$agegrp), info = "agegrp is factor by default")
+expect_equal(nrow(t1), 100L, info = "row count unchanged")
+expect_equal(as.character(t1$agegrp[1]), "<1", info = "age 0 -> <1")
+expect_equal(as.character(t1$agegrp[100]), "85+", info = "age 99 -> 85+")
+
+# custom max_age
+t2 <- to_agegrp(data.table(age = 0:99), max_age = 80L)
+expect_true("80+" %in% as.character(t2$agegrp), info = "custom max_age open band")
+
+# custom grp_width, to_factor FALSE
+t3 <- to_agegrp(data.table(age = 0:99), grp_width = 10, max_age = 85, to_factor = FALSE)
+expect_true(is.character(t3$agegrp), info = "to_factor=FALSE yields character")
+
+# custom column names + explicit min_age
+t4_in <- data.table(patient_age = c(3L, 7L, 40L))
+t4 <- to_agegrp(
+  t4_in,
+  grp_width = 5L,
+  max_age = 20L,
+  age_colname = "patient_age",
+  agegrp_colname = "age_cat",
+  to_factor = TRUE,
+  min_age = 0L
+)
+expect_true("age_cat" %in% names(t4), info = "custom agegrp_colname")
+expect_true(is.factor(t4$age_cat), info = "custom-named column is factor")
+expect_equal(as.character(t4$age_cat), c("01-04", "05-09", "20+"),
+             info = "to_agegrp values correct with explicit min_age/max_age")
+
+# error conditions
+expect_error(to_agegrp(as.data.frame(data.table(age = 0:9))),
+             info = "to_agegrp error on non-data.table")
+expect_error(to_agegrp(data.table(age = 0:9), age_colname = "nope"),
+             info = "to_agegrp error on missing age column")
+
+# =============================================================================
+# arrow_in
+# =============================================================================
+
+if (requireNamespace("arrow", quietly = TRUE)) {
+  expr <- arrow_in("sex", c("M", "F"))
+  expect_true(inherits(expr, "Expression"), info = "arrow_in returns Expression")
+
+  # Expression field input branch
+  expr2 <- arrow_in(arrow::Expression$field_ref("sex"), c("M", "F"))
+  expect_true(inherits(expr2, "Expression"), info = "arrow_in accepts Expression field")
+
+  # single value
+  expr3 <- arrow_in("age", 40L)
+  expect_true(inherits(expr3, "Expression"), info = "arrow_in single value works")
+
+  # Construct an in-memory arrow Table and filter with the expression to
+  # confirm the produced is_in expression is functional.
+  tbl <- arrow::arrow_table(
+    data.table(sex = c("M", "F", "M", "F"), age = c(30L, 40L, 50L, 40L))
+  )
+  filtered <- as.data.frame(
+    dplyr::filter(tbl, arrow_in("sex", "M"))
+  )
+  expect_equal(nrow(filtered), 2L, info = "arrow_in is_in filters table rows")
+  expect_true(all(filtered$sex == "M"), info = "arrow_in filter keeps matching values")
+
+  # error: empty values
+  expect_error(arrow_in("sex", character(0)),
+               info = "arrow_in errors on empty values")
+  # error: bad field (vector of length > 1)
+  expect_error(arrow_in(c("sex", "age"), "M"),
+               info = "arrow_in errors on non-scalar field")
+} else {
+  expect_true(TRUE, info = "arrow not available - skipping arrow_in tests")
+}

--- a/inst/tinytest/test-parquet_io.R
+++ b/inst/tinytest/test-parquet_io.R
@@ -1,0 +1,356 @@
+# Tests for parquet I/O helpers in misc_functions.R:
+#   write_parquet_dt(), read_parquet_dt(), arrow_in()
+#
+# Covers single-file and partitioned-dataset paths, all optional arguments,
+# key metadata preservation/restoration, and error/validation branches.
+
+# ---------------------------------------------------------------------------
+# Setup / dependency guards
+# ---------------------------------------------------------------------------
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  exit_file("data.table package not available")
+}
+if (!requireNamespace("arrow", quietly = TRUE)) {
+  exit_file("arrow package not available")
+}
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  exit_file("jsonlite package not available")
+}
+suppressMessages(library(data.table))
+
+set.seed(42)
+
+# Helper: compare two data.tables irrespective of row order / key state
+expect_dt_equal <- function(a, b, cols = NULL, info = "") {
+  a <- data.table::as.data.table(a)
+  b <- data.table::as.data.table(b)
+  if (is.null(cols)) cols <- intersect(names(a), names(b))
+  a <- a[, ..cols]
+  b <- b[, ..cols]
+  data.table::setcolorder(b, names(a))
+  data.table::setorderv(a, names(a))
+  data.table::setorderv(b, names(b))
+  data.table::setkey(a, NULL)
+  data.table::setkey(b, NULL)
+  expect_equal(a, b, info = info)
+}
+
+# A reusable keyed data.table
+make_dt <- function(n = 20L) {
+  dt <- data.table::data.table(
+    id    = seq_len(n),
+    year  = rep(2020:2023, length.out = n),
+    age   = 20L + seq_len(n),
+    sex   = rep(c("F", "M"), length.out = n),
+    value = rnorm(n)
+  )
+  data.table::setkey(dt, id, year)
+  dt[]
+}
+
+
+# ===========================================================================
+# arrow_in()
+# ===========================================================================
+
+# Returns an arrow Expression for a column name
+expr1 <- arrow_in("year", c(2020, 2021))
+expect_true(inherits(expr1, "Expression"), info = "arrow_in returns Expression")
+
+# Accepts an existing arrow::Expression as 'field'
+expr2 <- arrow_in(arrow::Expression$field_ref("year"), 2020)
+expect_true(inherits(expr2, "Expression"), info = "arrow_in accepts Expression field")
+
+# Single-value (scalar coerced to vector) works
+expr3 <- arrow_in("sex", "F")
+expect_true(inherits(expr3, "Expression"), info = "arrow_in single value")
+
+# Error: empty values vector
+expect_error(arrow_in("year", character(0)),
+             info = "arrow_in errors on empty values")
+
+# Error: field must be a single name or Expression
+expect_error(arrow_in(c("a", "b"), 1),
+             info = "arrow_in errors on multi-length field")
+expect_error(arrow_in(42, 1),
+             info = "arrow_in errors on non-character non-Expression field")
+
+
+# ===========================================================================
+# write_parquet_dt() / read_parquet_dt() -- single file round-trip
+# ===========================================================================
+
+dt <- make_dt()
+
+# --- default: preserve existing keys ---------------------------------------
+tf <- tempfile(fileext = ".parquet")
+res <- write_parquet_dt(dt, tf)
+expect_equal(res, tf, info = "write_parquet_dt returns path invisibly")
+expect_true(file.exists(tf), info = "single parquet file written")
+
+# Key metadata stored as JSON in r.data.table.keys
+pf <- arrow::read_parquet(tf, as_data_frame = FALSE)
+expect_equal(jsonlite::fromJSON(pf$metadata[["r.data.table.keys"]]),
+             c("id", "year"), info = "keys stored in metadata")
+
+got <- read_parquet_dt(tf)
+expect_true(data.table::is.data.table(got), info = "read returns data.table")
+expect_equal(data.table::key(got), c("id", "year"),
+             info = "keys restored from metadata")
+expect_dt_equal(got, dt, info = "single-file round-trip values equal")
+
+# --- explicit character keys -----------------------------------------------
+tf_k <- tempfile(fileext = ".parquet")
+write_parquet_dt(dt, tf_k, keys = c("age"))
+got_k <- read_parquet_dt(tf_k)
+expect_equal(data.table::key(got_k), "age", info = "explicit key restored")
+
+# --- impactncd key logic ----------------------------------------------------
+# Excludes mu/sigma/nu/tau/maxq/minq and cols ending in a digit, sorts, year last
+dti <- data.table::data.table(
+  year = 2020:2024, age = 30:34, sex = "M",
+  mu = rnorm(5), sigma = runif(5), tau = 1:5,
+  col2 = 1:5            # ends in digit -> excluded from keys
+)
+tf_i <- tempfile(fileext = ".parquet")
+write_parquet_dt(dti, tf_i, keys = "impactncd")
+got_i <- read_parquet_dt(tf_i)
+expect_equal(data.table::key(got_i), c("age", "sex", "year"),
+             info = "impactncd keys computed correctly")
+# column reordering puts keys first
+expect_equal(head(names(got_i), 3), c("age", "sex", "year"),
+             info = "impactncd reorders key columns first")
+
+# --- no keys at all ---------------------------------------------------------
+dt_nokey <- data.table::data.table(a = 1:3, b = 4:6)
+tf_nk <- tempfile(fileext = ".parquet")
+write_parquet_dt(dt_nokey, tf_nk)
+pf_nk <- arrow::read_parquet(tf_nk, as_data_frame = FALSE)
+expect_true(is.null(pf_nk$metadata[["r.data.table.keys"]]),
+            info = "no key metadata when data.table unkeyed")
+got_nk <- read_parquet_dt(tf_nk)
+expect_equal(length(data.table::key(got_nk)), 0L,
+             info = "no keys restored when none stored")
+expect_dt_equal(got_nk, dt_nokey, info = "unkeyed round-trip values equal")
+
+# --- compression options ----------------------------------------------------
+for (cmp in c("gzip", "zstd", "uncompressed")) {
+  tf_c <- tempfile(fileext = ".parquet")
+  write_parquet_dt(dt, tf_c, compression = cmp)
+  got_c <- read_parquet_dt(tf_c)
+  expect_dt_equal(got_c, dt, info = paste("compression round-trip:", cmp))
+}
+
+# --- factor column round-trip ----------------------------------------------
+dt_f <- data.table::data.table(g = factor(c("a", "b", "a", "b")), v = 1:4)
+data.table::setkey(dt_f, g)
+tf_f <- tempfile(fileext = ".parquet")
+write_parquet_dt(dt_f, tf_f)
+got_f <- read_parquet_dt(tf_f)
+expect_true(is.factor(got_f$g), info = "factor column preserved as factor")
+expect_equal(data.table::key(got_f), "g", info = "factor key restored")
+
+# --- data.frame input (coerced to data.table) ------------------------------
+df_in <- data.frame(x = 1:5, y = letters[1:5], stringsAsFactors = FALSE)
+tf_df <- tempfile(fileext = ".parquet")
+write_parquet_dt(df_in, tf_df)
+got_df <- read_parquet_dt(tf_df)
+expect_dt_equal(got_df, df_in, info = "data.frame input round-trip")
+
+
+# ===========================================================================
+# read_parquet_dt() -- optional arguments
+# ===========================================================================
+
+# --- column projection ------------------------------------------------------
+got_proj <- read_parquet_dt(tf, cols = c("id", "value"))
+expect_equal(sort(names(got_proj)), c("id", "value"),
+             info = "cols projection keeps only requested columns")
+# key not applied because not all key columns are present after projection
+expect_equal(length(data.table::key(got_proj)), 0L,
+             info = "keys dropped when key cols absent from projection")
+
+# --- row filter via arrow::Expression --------------------------------------
+got_filt <- read_parquet_dt(
+  tf, filter = arrow::Expression$field_ref("age") >= 30L)
+expect_true(all(got_filt$age >= 30L), info = "filter applied (age >= 30)")
+expect_equal(nrow(got_filt), sum(dt$age >= 30L),
+             info = "filter row count correct")
+
+# --- filter via arrow_in() --------------------------------------------------
+got_in <- read_parquet_dt(tf, filter = arrow_in("year", c(2020, 2021)))
+expect_true(all(got_in$year %in% c(2020, 2021)),
+            info = "arrow_in filter restricts years")
+
+# --- as_data_table = FALSE returns data.frame ------------------------------
+got_dfout <- read_parquet_dt(tf, as_data_table = FALSE)
+expect_false(data.table::is.data.table(got_dfout),
+             info = "as_data_table=FALSE returns plain data.frame")
+expect_true(is.data.frame(got_dfout),
+            info = "as_data_table=FALSE result is data.frame")
+
+# --- keys_fallback applied when no metadata keys ---------------------------
+got_fb <- read_parquet_dt(tf_nk, keys_fallback = c("a", "b"))
+expect_equal(data.table::key(got_fb), c("a", "b"),
+             info = "keys_fallback applied when no metadata keys")
+
+# --- keys_fallback ignored when columns missing ----------------------------
+got_fb2 <- read_parquet_dt(tf_nk, keys_fallback = c("nonexistent"))
+expect_equal(length(data.table::key(got_fb2)), 0L,
+             info = "keys_fallback ignored when columns absent")
+
+# --- metadata keys take precedence over keys_fallback ----------------------
+got_pref <- read_parquet_dt(tf, keys_fallback = c("age"))
+expect_equal(data.table::key(got_pref), c("id", "year"),
+             info = "metadata keys win over keys_fallback")
+
+# --- vector of files --------------------------------------------------------
+f1 <- tempfile(fileext = ".parquet")
+f2 <- tempfile(fileext = ".parquet")
+write_parquet_dt(dt[1:10], f1)
+write_parquet_dt(dt[11:20], f2)
+got_vec <- read_parquet_dt(c(f1, f2))
+expect_equal(nrow(got_vec), 20L, info = "vector-of-files reads all rows")
+expect_dt_equal(got_vec, dt, info = "vector-of-files round-trip values equal")
+
+
+# ===========================================================================
+# Partitioned-dataset code path
+# ===========================================================================
+
+# --- explicit partitioning column ------------------------------------------
+pdir <- tempfile()
+dir.create(pdir)
+write_parquet_dt(dt, pdir, partitioning = "year")
+# Hive-style directories created
+parts <- list.files(pdir)
+expect_true(all(grepl("^year=", parts)),
+            info = "hive partition directories created")
+expect_equal(length(parts), length(unique(dt$year)),
+             info = "one directory per partition value")
+
+got_part <- read_parquet_dt(pdir)
+expect_true(data.table::is.data.table(got_part),
+            info = "partitioned read returns data.table")
+expect_equal(nrow(got_part), nrow(dt),
+             info = "partitioned read returns all rows")
+expect_equal(data.table::key(got_part), c("id", "year"),
+             info = "keys restored from partitioned dataset metadata")
+expect_dt_equal(got_part, dt, info = "partitioned round-trip values equal")
+
+# --- partitioned read with projection + filter -----------------------------
+got_pf <- read_parquet_dt(
+  pdir,
+  cols   = c("id", "year", "value"),
+  filter = arrow_in("year", 2020))
+expect_true(all(got_pf$year == 2020),
+            info = "partitioned read with arrow_in filter")
+expect_equal(sort(names(got_pf)), c("id", "value", "year"),
+             info = "partitioned read with projection")
+
+# --- partitioning = TRUE auto-partitions by year ---------------------------
+pdir2 <- tempfile()
+dir.create(pdir2)
+write_parquet_dt(dt, pdir2, partitioning = TRUE)
+expect_true(all(grepl("^year=", list.files(pdir2))),
+            info = "partitioning=TRUE auto-partitions by year")
+
+# --- partitioning = TRUE with no 'year' column -> single file --------------
+pf_noyear <- tempfile(fileext = ".parquet")
+write_parquet_dt(dt_nokey, pf_noyear, partitioning = TRUE)
+expect_true(file.exists(pf_noyear) && !dir.exists(pf_noyear),
+            info = "partitioning=TRUE without year writes single file")
+
+
+# ===========================================================================
+# Pre-built sample data files (inst/testdata)
+# ===========================================================================
+
+sample_file <- system.file("testdata", "test_read_parquet.parquet",
+                            package = "CKutils")
+expect_true(nzchar(sample_file) && file.exists(sample_file),
+            info = "sample single parquet file exists")
+samp <- read_parquet_dt(sample_file)
+expect_true(data.table::is.data.table(samp),
+            info = "sample file read as data.table")
+expect_equal(sort(names(samp)), c("age", "id", "sex", "value"),
+             info = "sample file has expected columns")
+expect_equal(nrow(samp), 100L, info = "sample file has 100 rows")
+
+# keys_fallback on a sample file that lacks key metadata
+samp_fb <- read_parquet_dt(sample_file, keys_fallback = c("id", "age"))
+expect_equal(data.table::key(samp_fb), c("id", "age"),
+             info = "keys_fallback applied to sample file")
+
+# Pre-built partitioned dataset (partitioned by sex=F/M).
+# NOTE: open_dataset() with explicit partitioning="hive" errors in this arrow
+# version when partitions are auto-detected; read_parquet_dt's internal
+# tryCatch falls back to open_dataset() without partitioning, exercising that
+# recovery branch.
+sample_part <- system.file("testdata", "partitioned_test",
+                           package = "CKutils")
+expect_true(nzchar(sample_part) && dir.exists(sample_part),
+            info = "sample partitioned dataset exists")
+samp_p <- read_parquet_dt(sample_part)
+expect_true(data.table::is.data.table(samp_p),
+            info = "sample partitioned dataset read as data.table")
+expect_true("sex" %in% names(samp_p),
+            info = "partition column 'sex' present in result")
+expect_equal(nrow(samp_p), 100L,
+             info = "sample partitioned dataset has 100 rows")
+expect_true(all(c("F", "M") %in% unique(samp_p$sex)),
+            info = "both partition values present")
+
+# filter the sample partitioned dataset by partition column
+samp_pf <- read_parquet_dt(sample_part, filter = arrow_in("sex", "F"))
+expect_true(all(samp_pf$sex == "F"),
+            info = "filter on partitioned sample restricts to F")
+
+
+# ===========================================================================
+# Error / validation branches
+# ===========================================================================
+
+# write_parquet_dt: path must be a single string
+expect_error(write_parquet_dt(dt, c("a", "b")),
+             info = "write errors on non-scalar path")
+
+# write_parquet_dt: x must be data.table/data.frame/fst path
+expect_error(write_parquet_dt(42, tempfile()),
+             info = "write errors on invalid x type")
+
+# write_parquet_dt: missing key columns
+expect_error(write_parquet_dt(dt, tempfile(), keys = "zzz"),
+             info = "write errors on missing key columns")
+
+# write_parquet_dt: invalid keys type (not NULL/char/'impactncd')
+expect_error(write_parquet_dt(dt, tempfile(), keys = list(1)),
+             info = "write errors on invalid keys type")
+
+# write_parquet_dt: invalid partitioning type
+expect_error(write_parquet_dt(dt, tempfile(), partitioning = 42),
+             info = "write errors on invalid partitioning type")
+
+# write_parquet_dt: missing partitioning columns
+expect_error(write_parquet_dt(dt, tempfile(), partitioning = "zzz"),
+             info = "write errors on missing partitioning columns")
+
+# read_parquet_dt: filter must be an arrow::Expression
+expect_error(read_parquet_dt(tf, filter = "age >= 1"),
+             info = "read errors on non-Expression filter")
+
+# ---------------------------------------------------------------------------
+# fst-file input to write_parquet_dt (only if fst is available)
+# ---------------------------------------------------------------------------
+if (requireNamespace("fst", quietly = TRUE)) {
+  fst_in <- tempfile(fileext = ".fst")
+  fst::write_fst(as.data.frame(dt), fst_in)
+  tf_fst <- tempfile(fileext = ".parquet")
+  write_parquet_dt(fst_in, tf_fst, keys = c("id", "year"))
+  got_fst <- read_parquet_dt(tf_fst)
+  expect_equal(data.table::key(got_fst), c("id", "year"),
+               info = "fst input -> parquet preserves specified keys")
+  expect_equal(nrow(got_fst), nrow(dt),
+               info = "fst input round-trip row count")
+  expect_dt_equal(got_fst, dt, info = "fst input round-trip values equal")
+}

--- a/inst/tinytest/test-rng_distr.R
+++ b/inst/tinytest/test-rng_distr.R
@@ -1,0 +1,80 @@
+# Test suite for the random-generation wrappers in R/rng_distr.R
+# These functions (frXXX) draw high-quality uniforms via dqrng::dqrunif and
+# apply the corresponding inverse-CDF (fqXXX) transformation.
+
+# -----------------------------------------------------------------------------
+# Continuous distributions: frBCPEo, frBCT
+# -----------------------------------------------------------------------------
+cont_funs <- list(
+  frBCPEo = function(n, ...) frBCPEo(n, ...),
+  frBCT   = function(n, ...) frBCT(n, ...)
+)
+
+for (nm in names(cont_funs)) {
+  f <- cont_funs[[nm]]
+  set.seed(42)
+  x <- f(100, mu = 5, sigma = 0.1, nu = 1, tau = 2)
+  expect_equal(length(x), 100L, info = paste(nm, "returns requested length"))
+  expect_true(all(is.finite(x)), info = paste(nm, "produces finite values"))
+  expect_true(is.numeric(x), info = paste(nm, "returns numeric"))
+  # non-integer support for continuous distributions
+  expect_true(any(x != round(x)), info = paste(nm, "is continuous"))
+  # n is rounded up with ceiling()
+  expect_equal(length(f(9.2)), 10L, info = paste(nm, "ceilings non-integer n"))
+  # error on non-positive n
+  expect_error(f(0), info = paste(nm, "errors on n = 0"))
+  expect_error(f(-3), info = paste(nm, "errors on negative n"))
+}
+
+# parameter recycling for the continuous functions
+set.seed(1)
+expect_equal(length(frBCPEo(10, mu = c(1, 2), sigma = 0.3, nu = c(-0.5, 0.5), tau = 4)),
+             10L, info = "frBCPEo recycles parameters")
+set.seed(1)
+expect_equal(length(frBCT(10, mu = c(1, 2), sigma = 0.3, nu = c(-0.5, 0.5), tau = 4)),
+             10L, info = "frBCT recycles parameters")
+
+# -----------------------------------------------------------------------------
+# Count distributions: frBNB, frZIBNB, frZABNB, frDPO, frDEL,
+#                       frNBI, frZINBI, frZANBI, frSICHEL, frZISICHEL
+# -----------------------------------------------------------------------------
+# Each entry: function plus a list of valid parameters to exercise the body.
+count_calls <- list(
+  list(nm = "frBNB",      fun = frBNB,      args = list(mu = 1, sigma = 1, nu = 1)),
+  list(nm = "frZIBNB",    fun = frZIBNB,    args = list(mu = 1, sigma = 1, nu = 1, tau = 0.1)),
+  list(nm = "frZABNB",    fun = frZABNB,    args = list(mu = 1, sigma = 1, nu = 1, tau = 0.1)),
+  list(nm = "frDPO",      fun = frDPO,      args = list(mu = 1, sigma = 1)),
+  list(nm = "frDEL",      fun = frDEL,      args = list(mu = 1, sigma = 1, nu = 0.5)),
+  list(nm = "frNBI",      fun = frNBI,      args = list(mu = 2, sigma = 1)),
+  list(nm = "frZINBI",    fun = frZINBI,    args = list(mu = 2, sigma = 1, nu = 0.1)),
+  list(nm = "frZANBI",    fun = frZANBI,    args = list(mu = 2, sigma = 1, nu = 0.1)),
+  list(nm = "frSICHEL",   fun = frSICHEL,   args = list(mu = 2, sigma = 1, nu = -0.5)),
+  list(nm = "frZISICHEL", fun = frZISICHEL, args = list(mu = 2, sigma = 1, nu = -0.5, tau = 0.1))
+)
+
+for (cc in count_calls) {
+  set.seed(123)
+  x <- suppressWarnings(do.call(cc$fun, c(list(n = 200), cc$args)))
+  expect_equal(length(x), 200L, info = paste(cc$nm, "returns requested length"))
+  expect_true(all(is.finite(x)), info = paste(cc$nm, "produces finite values"))
+  # count distributions return non-negative integers
+  expect_true(all(x >= 0), info = paste(cc$nm, "is non-negative"))
+  expect_true(all(x == round(x)), info = paste(cc$nm, "returns integer counts"))
+  # ceiling of non-integer n
+  expect_equal(length(suppressWarnings(do.call(cc$fun, c(list(n = 4.1), cc$args)))),
+               5L, info = paste(cc$nm, "ceilings non-integer n"))
+  # error on non-positive n (covers the any(n <= 0) stop branch)
+  expect_error(do.call(cc$fun, c(list(n = 0), cc$args)),
+               info = paste(cc$nm, "errors on n = 0"))
+  expect_error(do.call(cc$fun, c(list(n = -2), cc$args)),
+               info = paste(cc$nm, "errors on negative n"))
+}
+
+# -----------------------------------------------------------------------------
+# Reproducibility: setting the dqrng seed yields identical draws
+# -----------------------------------------------------------------------------
+dqrng::dqset.seed(99)
+a <- frDPO(50, mu = 3, sigma = 1)
+dqrng::dqset.seed(99)
+b <- frDPO(50, mu = 3, sigma = 1)
+expect_equal(a, b, info = "frDPO is reproducible under a fixed dqrng seed")

--- a/inst/tinytest/test-shift_bypid_cpp.R
+++ b/inst/tinytest/test-shift_bypid_cpp.R
@@ -1,0 +1,90 @@
+# Direct tests for the exported C++ shift helpers in src/shift_bypid.cpp.
+# The R wrapper shift_bypid() validates/short-circuits inputs (empty vectors,
+# length mismatches, scalar replace), so several defensive branches in the C++
+# functions are only reachable by calling them directly.
+
+id  <- c(1L, 1L, 1L, 2L, 2L, 2L)
+num <- c(10, 20, 30, 40, 50, 60)
+
+# -----------------------------------------------------------------------------
+# shift_bypidNum
+# -----------------------------------------------------------------------------
+expect_equal(shift_bypidNum(numeric(0), 1L, NA_real_, integer(0)), numeric(0),
+             info = "shift_bypidNum: empty input returns empty")
+expect_error(shift_bypidNum(num, 1L, NA_real_, c(1L, 1L)), pattern = "must match",
+             info = "shift_bypidNum: length mismatch errors")
+expect_equal(shift_bypidNum(num, 1L, NA_real_, id), c(NA, 10, 20, NA, 40, 50),
+             info = "shift_bypidNum: positive lag within groups")
+expect_equal(shift_bypidNum(num, -1L, NA_real_, id), c(20, 30, NA, 50, 60, NA),
+             info = "shift_bypidNum: negative lag (lead) within groups")
+expect_equal(shift_bypidNum(num, 10L, -1, id), rep(-1, 6),
+             info = "shift_bypidNum: |lag| >= n fills with replace (positive)")
+expect_equal(shift_bypidNum(num, -10L, -1, id), rep(-1, 6),
+             info = "shift_bypidNum: |lag| >= n fills with replace (negative)")
+
+# -----------------------------------------------------------------------------
+# shift_bypidInt (preserves factor attributes)
+# -----------------------------------------------------------------------------
+ints <- c(10L, 20L, 30L, 40L, 50L, 60L)
+expect_equal(shift_bypidInt(integer(0), 1L, NA_integer_, integer(0)), integer(0),
+             info = "shift_bypidInt: empty input returns empty")
+expect_error(shift_bypidInt(ints, 1L, NA_integer_, c(1L, 1L)), pattern = "must match",
+             info = "shift_bypidInt: length mismatch errors")
+expect_equal(shift_bypidInt(ints, 1L, NA_integer_, id), c(NA, 10L, 20L, NA, 40L, 50L),
+             info = "shift_bypidInt: positive lag")
+expect_equal(shift_bypidInt(ints, -1L, NA_integer_, id), c(20L, 30L, NA, 50L, 60L, NA),
+             info = "shift_bypidInt: negative lag (lead)")
+
+# factor input: normal-lag branch preserves levels + class
+fac <- factor(c("a", "b", "c", "a", "b", "c"), levels = c("a", "b", "c"))
+res_fac <- shift_bypidInt(fac, 1L, NA_integer_, id)
+expect_equal(levels(res_fac), c("a", "b", "c"),
+             info = "shift_bypidInt: factor levels preserved (normal lag)")
+expect_true(is.factor(res_fac), info = "shift_bypidInt: result is a factor (normal lag)")
+
+# factor input: |lag| >= n branch also preserves factor attributes
+res_fac_big <- shift_bypidInt(fac, 10L, NA_integer_, id)
+expect_true(is.factor(res_fac_big),
+            info = "shift_bypidInt: factor preserved on |lag| >= n branch")
+expect_true(all(is.na(res_fac_big)),
+            info = "shift_bypidInt: |lag| >= n yields all replace")
+
+# non-factor integer, |lag| >= n
+expect_equal(shift_bypidInt(ints, -10L, -1L, id), rep(-1L, 6),
+             info = "shift_bypidInt: |lag| >= n fills with replace (negative)")
+
+# -----------------------------------------------------------------------------
+# shift_bypidBool
+# -----------------------------------------------------------------------------
+bools <- c(TRUE, FALSE, TRUE, FALSE, TRUE, FALSE)
+expect_equal(shift_bypidBool(logical(0), 1L, FALSE, integer(0)), logical(0),
+             info = "shift_bypidBool: empty input returns empty")
+expect_error(shift_bypidBool(bools, 1L, FALSE, c(1L, 1L)), pattern = "must match",
+             info = "shift_bypidBool: length mismatch errors")
+expect_error(shift_bypidBool(bools, 1L, logical(0), id), pattern = "at least one element",
+             info = "shift_bypidBool: empty replace errors")
+expect_equal(shift_bypidBool(bools, 1L, FALSE, id),
+             c(FALSE, TRUE, FALSE, FALSE, FALSE, TRUE),
+             info = "shift_bypidBool: positive lag")
+expect_equal(shift_bypidBool(bools, -1L, FALSE, id),
+             c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE),
+             info = "shift_bypidBool: negative lag (lead)")
+expect_equal(shift_bypidBool(bools, 9L, TRUE, id), rep(TRUE, 6),
+             info = "shift_bypidBool: |lag| >= n fills with replace")
+
+# -----------------------------------------------------------------------------
+# shift_bypidStr
+# -----------------------------------------------------------------------------
+chars <- c("a", "b", "c", "d", "e", "f")
+expect_equal(shift_bypidStr(character(0), 1L, "z", integer(0)), character(0),
+             info = "shift_bypidStr: empty input returns empty")
+expect_error(shift_bypidStr(chars, 1L, "z", c(1L, 1L)), pattern = "must match",
+             info = "shift_bypidStr: length mismatch errors")
+expect_equal(shift_bypidStr(chars, 1L, "miss", id),
+             c("miss", "a", "b", "miss", "d", "e"),
+             info = "shift_bypidStr: positive lag")
+expect_equal(shift_bypidStr(chars, -1L, "miss", id),
+             c("b", "c", "miss", "e", "f", "miss"),
+             info = "shift_bypidStr: negative lag (lead)")
+expect_equal(shift_bypidStr(chars, 8L, "miss", id), rep("miss", 6),
+             info = "shift_bypidStr: |lag| >= n fills with replace")

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,3 +3,5 @@
 *.dll
 symbols.rds
 src/*.o
+*.gcno
+*.gcda

--- a/src/lookup_dt.cpp
+++ b/src/lookup_dt.cpp
@@ -48,9 +48,9 @@ IntegerVector fct_to_int_cpp(SEXP x, bool inplace = false)
     }
     
     // Check if the factor has valid length
-    if (Rf_length(x) < 0) {
+    if (Rf_length(x) < 0) {        // # nocov start: R object length is never negative
         stop("Invalid factor length");
-    }
+    }                              // # nocov end
     
     IntegerVector result;
     if (inplace)
@@ -146,11 +146,11 @@ IntegerVector starts_from_1_cpp(DataFrame tbl, CharacterVector on, int i, List m
             }
             
             // Check for potential integer overflow/underflow
-            if (coldata[j] == INT_MIN || (coldata[j] - offset) < INT_MIN || (coldata[j] - offset) > INT_MAX) {
+            if (coldata[j] == INT_MIN || (coldata[j] - offset) < INT_MIN || (coldata[j] - offset) > INT_MAX) {  // # nocov start: defensive overflow guard, NA already handled
                 out[j] = NA_INTEGER;
                 continue;
-            }
-            
+            }                                                                                                    // # nocov end
+
             int val = coldata[j] - offset;
             if (val < 1 || val > card)
                 out[j] = NA_INTEGER;

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -61,10 +61,10 @@ NumericVector fquantile(NumericVector x, NumericVector probs, bool na_rm = true)
   // After na_omit, check if vector became empty
   const int n = x.size();
   if (n == 0)
-  {
+  {                                            // # nocov start: all-NA input already returned above
     NumericVector out(probs.size(), NA_REAL);
     return (out);
-  }
+  }                                            // # nocov end
 
   // Handle single element case - all quantiles are that single value
   if (n == 1)
@@ -86,10 +86,10 @@ NumericVector fquantile(NumericVector x, NumericVector probs, bool na_rm = true)
   }
   std::sort(x.begin(), x.end());
   out = x[as<IntegerVector>(lo) - 1];
-  if (all(is_na(ii)))
+  if (all(is_na(ii)))                          // # nocov start: ii is zero-initialised, never all-NA
   {
     return (out);
-  }
+  }                                            // # nocov end
   else
   {
     x = x[as<IntegerVector>(hi) - 1];
@@ -142,14 +142,14 @@ List fquantile_byid(NumericVector x,
   const int m = unique(id).size();
 
   // Safety check: m must be > 0
-  if (m == 0) {
+  if (m == 0) {                          // # nocov start: id is non-empty here (n > 0), so m >= 1
     List outputList(1 + q.size());
     outputList[0] = StringVector(0);
     for (int i = 1; i <= q.size(); i++) {
       outputList[i] = NumericVector(0);
     }
     return outputList;
-  }
+  }                                      // # nocov end
 
   NumericMatrix z(m, q.size());
   StringVector id_nam(m);
@@ -165,9 +165,9 @@ List fquantile_byid(NumericVector x,
     else
     {
       // Bounds check before accessing matrix
-      if (counter_row >= m) {
+      if (counter_row >= m) {   // # nocov start: defensive; group count never exceeds m
         stop("Internal error: counter_row exceeded expected number of groups");
-      }
+      }                         // # nocov end
       start = i - counter - 1;
       end = i - 1;
       counter = 0;
@@ -181,9 +181,9 @@ List fquantile_byid(NumericVector x,
   }
 
   // Bounds check for last group
-  if (counter_row >= m) {
+  if (counter_row >= m) {       // # nocov start: defensive; group count never exceeds m
     stop("Internal error: counter_row exceeded expected number of groups");
-  }
+  }                             // # nocov end
 
   // Handle the last group regardless of its size
   // Ensure start index is valid


### PR DESCRIPTION
Systematically test all functions/functionality with tinytest and mark
genuinely-untestable code with nocov. Offline coverage rises from ~75% to
~95% (higher in CI, where dependencies()'s network branches are reachable).

New test files (inst/tinytest):
- test-rng_distr.R: all frXXX random-generation wrappers
- test-misc_extra.R: agegrp_name, replace_from_table, to_agegrp,
  get_pcloud_path, arrow_in branch coverage
- test-parquet_io.R: write_parquet_dt / read_parquet_dt round-trips and
  all options (partitioning, compression, filters, metadata keys)
- test-gamlss_helpers.R: validate_gamlss, guess_gamlss, guess_polr,
  crossval_gamlss, reldist_diagnostics
- test-cklut_extra.R / test-cklut_shards.R: cklut build/lookup/print/
  to_dt/to_parquet/to_csv, value-type dispatch, and multi-shard + warm
  prefetch paths
- test-lookup_extra.R: lookup_dt validation/error branches
- test-dropbox_path.R: get_dropbox_path Linux path + error
- C++ branch tests: test-cpp_lookup_validation.R, test-shift_bypid_cpp.R,
  test-counts_cpp.R, test-misc_cpp.R, test-misc_cpp_branches.R,
  test-distr_cpp_branches.R (validation/log_p branches + compiled frXXX)

Fixes:
- guess_gamlss: stopifnot referenced `dt` (resolving to stats::dt) instead
  of the local `dtb`, so the function always errored before returning;
  corrected to `dtb`.

nocov: package load/unload hooks, real package-install machinery
(installLocalPackage*, dependencies' install.packages path), Windows-only
filesystem branches, requireNamespace guards for Suggests packages,
RevoUtilsMath (MKL) branches, and unreachable defensive guards in
src/lookup_dt.cpp and src/misc_functions.cpp.

Also ignore gcov (*.gcno/*.gcda) build artifacts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URXYnpuXd3gcfE48XmkPNy